### PR TITLE
Cleanup and renaming in history

### DIFF
--- a/bublik/interfaces/api_v2/history.py
+++ b/bublik/interfaces/api_v2/history.py
@@ -99,7 +99,6 @@ class HistoryViewSet(ListModelMixin, GenericViewSet):
         tests = get_tests_by_name(test_name)
         if not tests:
             raise ValidationError(detail='Invalid test name', code=status.HTTP_404_NOT_FOUND)
-        test_ids = list(tests.values_list('id', flat=True))
 
         ### Apply run filters ###
 
@@ -147,6 +146,7 @@ class HistoryViewSet(ListModelMixin, GenericViewSet):
         ### Apply iteration filters ###
 
         # Filter test iterations by test name
+        test_ids = list(tests.values_list('id', flat=True))
         test_iterations = TestIteration.objects.filter(test__in=test_ids)
 
         # Filter test iterations by hash


### PR DESCRIPTION
1. Use more appropriate names for query parameters and variables
2. Structure the code, add comments