### PR TITLE
Fix strange percentages in run statistics

### DIFF
--- a/bublik/core/importruns/live/context.py
+++ b/bublik/core/importruns/live/context.py
@@ -603,11 +603,6 @@ class LiveLogContext:
         if 'ts' not in data:
             msg = 'timestamp is required'
             raise LLInvalidInputError(msg)
-
         dt = utc_ts_to_dt(data['ts'])
-
-        on_item_enter, on_item_exit = self.plan_skip_handlers()
-        self.plan_tracker.skip_all(on_item_enter, on_item_exit)
-
         self.last_ts = dt
         self.finish_run('RUN_STATUS_DONE')

--- a/bublik/core/importruns/live/context.py
+++ b/bublik/core/importruns/live/context.py
@@ -338,7 +338,7 @@ class LiveLogContext:
                 iteration=test_iteration,
                 run=self.run,
                 parent_package=parent_result,
-                tin=-1,
+                tin=-2,
                 exec_seqno=self.current_seqno,
             )
             self.push_stack_item(

--- a/bublik/core/importruns/source/execution.py
+++ b/bublik/core/importruns/source/execution.py
@@ -19,6 +19,7 @@ from bublik.core.run.objects import (
     add_tags,
     add_test,
     clear_run_count,
+    del_blank_iteration_results,
     set_prologues_counts,
     set_run_count,
     set_run_import_mode,
@@ -124,8 +125,10 @@ def incremental_import(run_log, meta_data, run_completed, force):
             force_update = True
             if was_online:
                 logger.info('this is a reupload of an online import')
+                del_blank_iteration_results(run_id)
             if force:
                 logger.info('this is a re-import of an already imported run')
+                del_blank_iteration_results(run_id)
             logger.info(f'the run will be fully added, finish timestamp - {run_finish}')
     else:
         run_data = {'test_run': None, 'start': run_start}


### PR DESCRIPTION
Fix issue #22 by fix blank test iteration result objects processing:
1. Do not create unnecessary blank objects
2. Use a special tin for blank objects
3. Update blank objects instead of creating duplicates
4. Add the ability to search and delete blank objects