### PR TITLE
Fix negative values in detailed run stats

### DIFF
--- a/bublik/core/run/stats.py
+++ b/bublik/core/run/stats.py
@@ -113,9 +113,9 @@ def generate_result(test_iter_res, parent, period, path, info, run_results):
 
         unexpected = test_iterations.filter(meta_results__meta__type='err')
 
-        passed_unexpected = passed(unexpected).count()
-        failed_unexpected = failed(unexpected).count()
-        skipped_unexpected = skipped(unexpected).count()
+        passed_unexpected = passed(unexpected).distinct().count()
+        failed_unexpected = failed(unexpected).distinct().count()
+        skipped_unexpected = skipped(unexpected).distinct().count()
 
         test_iter_res_info['stats']['passed'] = all_passed - passed_unexpected
         test_iter_res_info['stats']['failed'] = all_failed - failed_unexpected

--- a/bublik/core/run/stats.py
+++ b/bublik/core/run/stats.py
@@ -180,8 +180,7 @@ def get_run_stats_detailed(run_id):
     cache = RunCache.by_id(run_id, 'stats')
     run_stats = cache.data
     # Recalculating statistics if it is not stored in the cache
-    # or has an old structure that the UI does not support
-    if not run_stats or 'stats' not in run_stats.keys():
+    if not run_stats:
         run_results = (
             TestIterationResult.objects.filter(test_run=run_id)
             .order_by('start')

--- a/bublik/interfaces/api_v2/__init__.py
+++ b/bublik/interfaces/api_v2/__init__.py
@@ -22,7 +22,7 @@ from .history import HistoryViewSet
 from .importruns import ImportrunsViewSet
 from .index import render_react
 from .log import LogViewSet
-from .management import local_logs, meta_categorization
+from .management import clear_all_runs_stats_cache, local_logs, meta_categorization
 from .measurements import MeasurementViewSet
 from .outside_domains import OutsideDomainsViewSet
 from .performance import PerformanceCheckView
@@ -58,4 +58,5 @@ __all__ = [
     'ForgotPasswordResetView',
     'AdminViewSet',
     'PerformanceCheckView',
+    'clear_all_runs_stats_cache',
 ]

--- a/bublik/interfaces/api_v2/management.py
+++ b/bublik/interfaces/api_v2/management.py
@@ -33,3 +33,10 @@ def local_logs(request, task_id):
             'bublik/alert.html',
             {'detail': str(e), 'view': 'local_logs', 'alert_type': 'danger'},
         )
+
+
+@never_cache
+@api_view(['GET', 'POST'])
+def clear_all_runs_stats_cache(request):
+    task_id = tasks.clear_all_runs_stats_cache.delay()
+    return HttpResponse(f'\nYour task id: {task_id}\n')

--- a/bublik/urls.py
+++ b/bublik/urls.py
@@ -40,6 +40,11 @@ urlpatterns = [
     # Management commands web interface
     path('importruns/', include(importruns_router.urls)),
     path('meta_categorization/', api_v2.meta_categorization, name='meta_categorization'),
+    path(
+        'clear_all_runs_stats_cache/',
+        api_v2.clear_all_runs_stats_cache,
+        name='clear_all_runs_stats_cache',
+    ),
     re_path(r'importlog/(?:(?P<task_id>[a-fA-F-\d]{36})?)$',
             cache_page(60 * 20)(api_v2.local_logs), name='logs'),
     # V2


### PR DESCRIPTION
Fix issue #20 by fix detailed stats calculation:
1. Fix the calculation of NOK iteration results number
2. Add the ability to drop detailed stats from cache for all runs
3. Calculate detailed stats only if they are not in the cache
