### PR TITLE
Add URL shortner

### DIFF
--- a/bublik/core/hash_system.py
+++ b/bublik/core/hash_system.py
@@ -88,7 +88,14 @@ class HashedModelSerializer(ModelSerializer):
         return super().create(self.validated_data_and_hash)
 
     def get_or_create(self):
-        return self.Meta.model.objects.get_or_create(**self.validated_data_and_hash)
+        hash_value = self.validated_data_and_hash.get('hash')
+        obj = self.get_or_none(hash=hash_value)
+
+        if obj:
+            return obj, False
+
+        obj = self.Meta.model.objects.create(**self.validated_data_and_hash)
+        return obj, True
 
     @property
     def validated_data_and_hash(self):

--- a/bublik/data/models/__init__.py
+++ b/bublik/data/models/__init__.py
@@ -21,6 +21,7 @@ The database is capable to keep thousands of test runs which contain thousands
 of test iteration results.
 '''
 
+from .endpoint_url import EndpointURL
 from .eventlog import EventLog
 from .expectation import Expectation, ExpectMeta
 from .measurement import (
@@ -79,4 +80,5 @@ __all__ = [
     'User',
     'UserManager',
     'UserRoles',
+    'EndpointURL',
 ]

--- a/bublik/data/models/endpoint_url.py
+++ b/bublik/data/models/endpoint_url.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
+
+
+from django.db import models
+
+
+__all__ = [
+    'EndpointURL',
+]
+
+
+class EndpointURL(models.Model):
+    '''
+    The endpoints of Bublik URLs and the corresponding hashes used for short URLs.
+    '''
+
+    hashable = (
+        'view',
+        'endpoint',
+    )
+    created = models.DateTimeField(help_text='Timestamp of the short URL creation.')
+    view = models.TextField(help_text='The Bublik URL view.')
+    endpoint = models.TextField(help_text='The Bublik URL endpoint.')
+    hash = models.CharField(
+        max_length=16,
+        unique=True,
+        help_text='The Bublik URL endpoint hash.',
+    )
+
+    class Meta:
+        db_table = 'bublik_endpoint_url'
+
+    def __repr__(self):
+        return (
+            f'EndpointURL(created={self.created!r}, view={self.view!r}, '
+            f'endpoint={self.endpoint!r}, hash={self.hash!r})'
+        )

--- a/bublik/data/serializers/__init__.py
+++ b/bublik/data/serializers/__init__.py
@@ -9,6 +9,7 @@ from .auth import (
     UserEmailSerializer,
     UserSerializer,
 )
+from .endpoint_url import EndpointURLSerializer
 from .eventlog import EventLogSerializer
 from .expectation import (
     ExpectationSerializer,
@@ -54,4 +55,5 @@ __all__ = [
     'UserEmailSerializer',
     'PasswordResetSerializer',
     'UpdateUserSerializer',
+    'EndpointURLSerializer',
 ]

--- a/bublik/data/serializers/endpoint_url.py
+++ b/bublik/data/serializers/endpoint_url.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
+
+from base64 import b64encode
+from hashlib import blake2s
+
+from bublik.core.hash_system import HashedModelSerializer
+from bublik.data.models import EndpointURL
+
+
+__all__ = [
+    'EndpointURLSerializer',
+]
+
+
+def blake2sb64hex(obj):
+    if isinstance(obj, str):
+        obj = obj.encode('utf-8')
+    enc_key = blake2s(obj, digest_size=8).digest()
+    return b64encode(enc_key).decode('utf-8')
+
+
+class EndpointURLSerializer(HashedModelSerializer):
+    class Meta:
+        model = EndpointURL
+        fields = ('created', 'view', 'endpoint')
+
+    def create_hash(self, data, hasher=blake2sb64hex):
+        return super().create_hash(data, hasher)
+
+    def update_hash(self, hasher=blake2sb64hex):
+        return super().update_hash(hasher)

--- a/bublik/interfaces/api_v2/__init__.py
+++ b/bublik/interfaces/api_v2/__init__.py
@@ -30,6 +30,7 @@ from .report import ReportViewSet
 from .results import ResultViewSet, RunViewSet
 from .server import ServerViewSet
 from .tree import TreeViewSet
+from .url_shortener import URLShortnerView
 
 
 __all__ = [
@@ -61,4 +62,5 @@ __all__ = [
     'PerformanceCheckView',
     'clear_all_runs_stats_cache',
     'ReportViewSet',
+    'URLShortnerView',
 ]

--- a/bublik/interfaces/api_v2/url_shortener.py
+++ b/bublik/interfaces/api_v2/url_shortener.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
+
+from datetime import datetime
+import re
+
+from django.conf import settings
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from bublik.core.run.utils import prepare_date
+from bublik.core.shortcuts import build_absolute_uri, serialize
+from bublik.data.serializers import EndpointURLSerializer
+
+
+class URLShortnerView(APIView):
+    def get(self, request, *args, **kwargs):
+        '''
+        Return a short URL corresponding to the passed URL.
+        Short URL format is 'http://<host name>/bublik/eh/<hash>'.
+        Route: /url_shortner.
+        '''
+        # Get URL to be shortened
+        url = self.request.query_params.get('url', '')
+
+        # Check URL preffix
+        url_head = build_absolute_uri(request, settings.UI_PREFIX)
+        if url.find(url_head) != 0:
+            msg = 'The passed URL has an incorrect prefix'
+            return Response({'message': msg}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Get view and endpoint
+        url_tail = url.replace(url_head + '/', '', 1)
+        view = re.split(r'/|\?', url_tail, 1)[0]
+        endpoint = url_tail.replace(view, '', 1)
+
+        # Get or create EndpointURL object
+        short_url_serializer = serialize(
+            EndpointURLSerializer,
+            {'created': prepare_date(datetime.now()), 'view': view, 'endpoint': endpoint},
+        )
+        short_url_obj, _ = short_url_serializer.get_or_create()
+
+        # Build short URL with the hash of the endpoint of the passed URL
+        short_url_endpoint = f'short/{view}/{short_url_obj.hash}'
+        short_url = build_absolute_uri(request, short_url_endpoint)
+
+        return Response(data={'short_url': short_url}, status=status.HTTP_200_OK)

--- a/bublik/interfaces/main_api/__init__.py
+++ b/bublik/interfaces/main_api/__init__.py
@@ -9,6 +9,7 @@ from .redirects import (
     redirect_root,
     redirect_run_stats,
     redirect_runs_stats,
+    redirect_short,
     redirect_tests_run,
 )
 
@@ -22,4 +23,5 @@ __all__ = [
     'redirect_runs_stats',
     'redirect_tests_run',
     'redirect_flower',
+    'redirect_short',
 ]

--- a/bublik/interfaces/main_api/redirects.py
+++ b/bublik/interfaces/main_api/redirects.py
@@ -2,10 +2,13 @@
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpResponseNotFound
 from django.shortcuts import redirect
 
 from bublik.core.run.tests_organization import get_run_root
 from bublik.core.shortcuts import build_absolute_uri
+from bublik.data.models import EndpointURL
 
 
 def redirect_root(request):
@@ -55,3 +58,14 @@ def redirect_next(request):
 def redirect_flower(request):
     flower_url = (request, 'flower')
     return redirect(flower_url)
+
+
+def redirect_short(request, view_endpoint_hash):
+    view, endpoint_hash = view_endpoint_hash.split('/', 1)
+    try:
+        endpoint_by_hash = EndpointURL.objects.get(hash=endpoint_hash).endpoint
+    except ObjectDoesNotExist:
+        return HttpResponseNotFound('<h1>Page not found</h1>')
+    new_endpoint = f'{settings.UI_PREFIX}/{view}{endpoint_by_hash}'
+    new_view_path = build_absolute_uri(request, new_endpoint)
+    return redirect(new_view_path)

--- a/bublik/urls.py
+++ b/bublik/urls.py
@@ -81,6 +81,7 @@ urlpatterns = [
         name='auth_forgot_password_password_reset',
     ),
     path('performance_check/', api_v2.PerformanceCheckView.as_view(), name='performance_check'),
+    path('url_shortner/', api_v2.URLShortnerView.as_view(), name='url_shortner'),
 ]
 
 if settings.URL_PREFIX:

--- a/bublik/urls.py
+++ b/bublik/urls.py
@@ -54,6 +54,7 @@ urlpatterns = [
     path('api/v2/', include((api_v2_router.urls, 'api-v2'), namespace='api-v2')),
     # Redirects
     path('', main_api.redirect_root),
+    re_path(r'short/(?P<view_endpoint_hash>[A-Za-z0-9+/=]+)$', main_api.redirect_short),
     path('dashboard/', main_api.redirect_dashboard),
     path('v1/runs_stats/', main_api.redirect_runs_stats),
     path('v1/flower/', main_api.redirect_flower, name='flower_site'),


### PR DESCRIPTION
### Info

1. The `HashedModelSerializer` has been changed to be able to serialize model objects, not all fields of which are hashable.
2. `EndpointURL` model, the corresponding serializer `EndpointURLSerializer` and `URLShortnerView` have been created. It allows you to create short URLs by replacing the endpoint of passed Bublik URL with its hash. All created hashes are stored in the database along with the corresponding views and endpoints to be able to redirect short URLs. The time of creation of the short URL is also stored in the database.

#### Example

Bublik URL:
`http://localhost/bublik/v2/history?mode=linear&page=1&results=PASSED%3BFAILED%3BKILLED%3BCORED%3BSKIPPED%3BFAKED%3BINCOMPLETE&verdictLookup=string&startDate=2023-12-07&finishDate=2024-03-10&testName=promiscuous_mode&runProperties=notcompromised&parameters=env%3DVAR.env.peer2peer%3Bethdev_state%3DINITIALIZED%3Bis_promiscuous_mode%3DFALSE%3Btmpl%3DVAR.tmpl.tst2iut.eth`

Corresponding short URL:
`http://localhost/bublik/short/history/Krue8imt+as=`

### Usage

Request: `GET /bublik/url_shortner/?url=<complete Bublik URL>)`

Response data:

```
{
    "short_url": "<protocol>://<host name>/bublik/short/<view>/<endpoint hash>",
}
```