### PR TITLE
Add the ability to build run reports

### DIFF
--- a/bublik/core/report/components.py
+++ b/bublik/core/report/components.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
+
+import copy
+
+from itertools import groupby
+
+from bublik.core.report.services import args_sort, sequence_name_conversion, type_conversion
+
+
+'''
+The report consists of blocks corresponding to the tests. Inside each of these blocks
+there are records corresponding to a certain set of arguments. The points on each of the record
+are combined into sequences according to the value of one specific argument and regrouded
+into datasets according to axis x values (more convenient for UI).
+'''
+
+
+class ReportPoint:
+    '''
+    This class describes the points of records and the functions
+    used to group them by tests, records, sequences and axix x value.
+    '''
+
+    def __init__(self, mmr, common_args, report_config):
+        '''
+        Build the point object based on the measurement result
+        according to report config.
+        '''
+        self.test_name = mmr.result.iteration.test.name
+        test_config = report_config['tests'][self.test_name]
+
+        self.args_vals = {}
+        self.axis_x = test_config['axis_x']
+        self.axis_y = None
+        self.sequence_group_arg = test_config['sequence_group_arg']
+        self.sequence_group_arg_val = None
+        self.point = {}
+
+        # collect test arguments values, value of sequence argument and the point
+        for arg in mmr.result.iteration.test_arguments.all():
+            if arg.name == self.axis_x:
+                self.point[type_conversion(arg.value)] = mmr.value
+            elif arg.name == self.sequence_group_arg:
+                # ID is needed to maintain order when sorting before
+                # it is grouped in the future
+                self.sequence_group_arg_val = (
+                    arg.id,
+                    sequence_name_conversion(arg.value, test_config),
+                )
+            elif arg.name not in common_args[self.test_name].keys():
+                self.args_vals[arg.name] = arg.value
+
+        # form the name of the y axis from the corresponding metas
+        metas = {}
+        for meta in mmr.measurement.metas.filter(
+            type='measurement_subject',
+            name__in=['name', 'type', 'base_units', 'multiplier'],
+        ):
+            metas[meta.name] = meta.value
+        if 'name' in metas:
+            self.axis_y = f"{metas['name']} ({metas['base_units']} * {metas['multiplier']})"
+        else:
+            self.axis_y = f"{metas['type']} ({metas['base_units']} * {metas['multiplier']})"
+
+    def points_grouper_tests(self):
+        return self.test_name
+
+    def points_grouper_records(self):
+        return list(self.args_vals.values()), self.axis_y
+
+    def points_grouper_sequences(self):
+        return self.sequence_group_arg_val
+
+
+class ReportRecord:
+    '''
+    This class describes the records.
+    '''
+
+    def __init__(self, record_info, record_points, test_name, report_config):
+        test_config = report_config['tests'][test_name]
+        table_view = test_config['table_view']
+        chart_view = test_config['chart_view']
+
+        self.type = 'record-entity'
+        self.warnings = []
+        self.args_vals = record_points[0].args_vals
+        self.id = self.label = self.build_id_and_label()
+        self.sequence_group_arg = test_config['sequence_group_arg']
+        self.axis_x_key = test_config['axis_x']
+        self.axis_x_label = test_config['axis_x']
+        self.axis_y_label = record_info[1]
+
+        if table_view or chart_view:
+            # group points into sequences
+            sequences, string_args = self.get_sequences_and_str_args(record_points)
+            dataset = self.create_dataset(sequences, test_config)
+
+        if table_view:
+            self.dataset_table = copy.deepcopy(dataset)
+            self.percentage_calc(self.dataset_table[0], test_config)
+
+        if chart_view:
+            if string_args:
+                self.warnings.append(
+                    f'Invalid values \'{string_args}\' of the axis x argument for plotting '
+                    'the chart. Chart building is skipped.',
+                )
+            else:
+                self.dataset_chart = copy.deepcopy(dataset)
+
+    def build_id_and_label(self):
+        '''
+        Build record id and label.
+        '''
+        label_list = []
+        for _, val in self.args_vals.items():
+            label_list.append(str(val))
+        return '-'.join(label_list)
+
+    def get_sequences_and_str_args(self, record_points):
+        '''
+        Group points into sequences. Get string arguments.
+        '''
+        sequences = {}
+        string_args = set()
+        record_points = sorted(record_points, key=ReportPoint.points_grouper_sequences)
+        for seq_arg_id_and_val, sequence_points in groupby(
+            record_points,
+            ReportPoint.points_grouper_sequences,
+        ):
+            sequence_group_arg_val = seq_arg_id_and_val[1]
+            # add points to the corresponding sequence
+            sequence = {}
+            for sequence_point in list(sequence_points):
+                for arg, val in sequence_point.point.items():
+                    if type(arg) != int:
+                        string_args.add(arg)
+                    sequence[arg] = val
+            sequences[sequence_group_arg_val] = sequence
+        return sequences, string_args
+
+    def create_dataset(self, sequences, test_config):
+        '''
+        Regroup points into datasets that are more convenient for UI.
+        '''
+        dataset = []
+        for axis_x_val in list(sequences.values())[0]:
+            dataset.append([axis_x_val])
+        dataset_labels = [self.axis_x_key]
+        for sequence_group_arg_val, sequence in sequences.items():
+            dataset_labels.append(
+                sequence_name_conversion(sequence_group_arg_val, test_config),
+            )
+            for i, point in enumerate(sequence.values()):
+                dataset[i].append(point)
+        dataset.insert(0, dataset_labels)
+        return dataset
+
+    def percentage_calc(self, dataset_labels, test_config):
+        '''
+        Calculate gain relative to "base" sequence.
+        '''
+        percentage_base_value = test_config['percentage_base_value']
+        percentage_base_value = sequence_name_conversion(percentage_base_value, test_config)
+        if percentage_base_value is not None:
+            if percentage_base_value in dataset_labels:
+                pbv_idx = dataset_labels.index(percentage_base_value)
+                for dataset_label in dataset_labels[1:]:
+                    if dataset_label != percentage_base_value:
+                        self.dataset_table[0].append(f'{dataset_label} gain')
+                        idx = dataset_labels.index(dataset_label)
+                        for dataset_record in self.dataset_table[1:]:
+                            if dataset_record[pbv_idx]:
+                                percentage = round(
+                                    100 * (dataset_record[idx] / dataset_record[pbv_idx] - 1),
+                                    2,
+                                )
+                            else:
+                                percentage = 0
+                            dataset_record.append(percentage)
+            else:
+                self.warnings.append(
+                    f'There is no sequence corresponding to the passed '
+                    f'base value \'{percentage_base_value}\'. '
+                    'Persentage calculation is skipped.',
+                )
+
+
+class ReportTest:
+    '''
+    This class describes the report blocks corresponding to the tests.
+    '''
+
+    def __init__(self, test_name, common_args, test_points, report_config):
+        test_config = report_config['tests'][test_name]
+        records_order = test_config['records_order']
+
+        self.type = 'test-block'
+        self.id = test_name
+        self.label = test_name
+        self.enable_table_view = test_config['table_view']
+        self.enable_chart_view = test_config['chart_view']
+        self.common_args = common_args[test_name]
+        self.content = []
+
+        for test_point in test_points:
+            try:
+                test_point.args_vals = args_sort(
+                    records_order,
+                    test_point.args_vals,
+                )
+            except KeyError as incorrect_arg:
+                msg = (
+                    f'incorrect argument {incorrect_arg} in \'records_order\' for '
+                    f'\'{test_name}\' test in the configuration. '
+                    f'Check that {incorrect_arg} is not a sequence argument or an argument '
+                    'that has the same value for all iterations.'
+                )
+                raise ValueError(msg) from incorrect_arg
+        test_points = sorted(test_points, key=ReportPoint.points_grouper_records)
+
+        for record_info, record_points in groupby(
+            test_points,
+            ReportPoint.points_grouper_records,
+        ):
+            record = ReportRecord(record_info, list(record_points), test_name, report_config)
+            self.content.append(record.__dict__)

--- a/bublik/core/report/services.py
+++ b/bublik/core/report/services.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
 
+import contextlib
+
+from itertools import groupby
 import json
 import os
 
 from bublik import settings
-from bublik.data.models import Meta
+from bublik.data.models import MeasurementResult, Meta, TestArgument
 from bublik.settings import REPORT_CONFIG_COMPONENTS
 
 
@@ -67,3 +70,108 @@ def build_report_title(main_pkg, title_content):
         if title_obj in meta_labels:
             title.append(meta_labels[title_obj])
     return '-'.join(title)
+
+
+def type_conversion(arg_value):
+    with contextlib.suppress(AttributeError):
+        if arg_value.isdigit():
+            return int(arg_value)
+    return arg_value
+
+
+def sequence_name_conversion(seq_arg_val, test_config):
+    '''
+    Convert the passed sequence name according to the passed test configuration.
+    '''
+    seq_arg_val = str(seq_arg_val)
+    sequence_name_conversion = test_config['sequence_name_conversion']
+    with contextlib.suppress(KeyError):
+        return str(sequence_name_conversion[seq_arg_val])
+    return seq_arg_val
+
+
+def args_type_convesion(point_groups_by_test_name):
+    '''
+    The argument values are used to sort the records. Thus, for proper sorting, it is necessary
+    to determine numeric arguments and convert their values from str to int.
+    '''
+    args_to_convert = {}
+    for test_name, test_points in point_groups_by_test_name.items():
+        args_to_convert[test_name] = set(test_points[0].args_vals.keys())
+        for test_point in test_points:
+            for arg, val in test_point.args_vals.items():
+                if not isinstance(type_conversion(val), int):
+                    args_to_convert[test_name].discard(arg)
+
+    for test_name, test_points in point_groups_by_test_name.items():
+        for test_point in test_points:
+            for arg in args_to_convert[test_name]:
+                test_point.args_vals[arg] = type_conversion(test_point.args_vals[arg])
+
+    return point_groups_by_test_name
+
+
+def args_sort(records_order, args_vals):
+    if records_order:
+        return dict([arg, args_vals[arg]] for arg in records_order)
+    return dict(sorted(args_vals.items()))
+
+
+def get_common_args(main_pkg, test_name):
+    '''
+    Collect arguments that have the same values for all iterations of the test
+    with the passed name within the passed package.
+    '''
+    common_args = {}
+    test_args = (
+        TestArgument.objects.filter(
+            test_iterations__testiterationresult__test_run=main_pkg,
+            test_iterations__test__name=test_name,
+        )
+        .order_by('name', 'value')
+        .distinct('name', 'value')
+        .values('name', 'value')
+    )
+
+    for arg, arg_val in groupby(test_args, key=lambda x: x['name']):
+        arg_val = list(arg_val)
+        if len(arg_val) == 1:
+            common_args[arg] = type_conversion(arg_val[0]['value'])
+
+    return common_args
+
+
+def filter_by_axis_y(mmrs_test, axis_y):
+    '''
+    Filter passed measurement results QS by axis y value from config.
+    '''
+    for meas_type, meas_names in axis_y.items():
+        mmrs_test = mmrs_test.filter(
+            measurement__metas__name='type',
+            measurement__metas__type='measurement_subject',
+            measurement__metas__value=meas_type,
+        )
+        if meas_names:
+            mmrs_test = mmrs_test.filter(
+                measurement__metas__name='name',
+                measurement__metas__type='measurement_subject',
+                measurement__metas__value__in=meas_names,
+            )
+
+    return mmrs_test
+
+
+def filter_by_not_show_args(mmrs_test, not_show_args):
+    '''
+    Drop measurement results corresponding to iterations with the passed
+    arguments values from the passed measurement results QS.
+    '''
+    not_show_mmrs = MeasurementResult.objects.none()
+    for arg, vals in not_show_args.items():
+        arg_vals_mmrs = mmrs_test.filter(
+            result__iteration__test_arguments__name=arg,
+            result__iteration__test_arguments__value__in=vals,
+        )
+        not_show_mmrs = not_show_mmrs.union(arg_vals_mmrs)
+
+    return mmrs_test.difference(not_show_mmrs)

--- a/bublik/core/report/services.py
+++ b/bublik/core/report/services.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
+
+import json
+import os
+
+from bublik import settings
+from bublik.data.models import Meta
+from bublik.settings import REPORT_CONFIG_COMPONENTS
+
+
+def get_report_config():
+    report_configs_dir = os.path.join(settings.PER_CONF_DIR, 'report_configs')
+    for root, _, report_config_files in os.walk(report_configs_dir):
+        for report_config_file in report_config_files:
+            with open(os.path.join(root, report_config_file)) as rсf:
+                try:
+                    report_config = json.load(rсf)
+                    yield report_config_file, report_config
+                except json.decoder.JSONDecodeError:
+                    yield report_config_file, None
+
+
+def get_report_config_by_id(report_config_id):
+    for _, report_config in get_report_config():
+        if report_config:
+            try:
+                if str(report_config['id']) == report_config_id:
+                    return report_config
+            except KeyError:
+                continue
+    return None
+
+
+def check_report_config(report_config):
+    '''
+    Check the passed report config for compliance with the expected format.
+    '''
+    for key in REPORT_CONFIG_COMPONENTS['required_keys']:
+        if key not in report_config.keys():
+            msg = f'the required key \'{key}\' is missing in the configuration'
+            raise KeyError(msg)
+
+    for test_name, test_configuration in report_config['tests'].items():
+        for key in REPORT_CONFIG_COMPONENTS['required_test_keys']:
+            if key not in test_configuration.keys():
+                msg = (
+                    f'the required key \'{key}\' is missing for \'{test_name}\' '
+                    'test in the configuration'
+                )
+                raise KeyError(msg)
+
+
+def build_report_title(main_pkg, title_content):
+    '''
+    Form the title of the report according to configuration.
+    '''
+    meta_labels = Meta.objects.filter(
+        metaresult__result__id=main_pkg.id,
+        type='label',
+        name__in=title_content,
+    ).values_list('name', 'value')
+    meta_labels = dict(meta_labels)
+
+    title = []
+    for title_obj in title_content:
+        if title_obj in meta_labels:
+            title.append(meta_labels[title_obj])
+    return '-'.join(title)

--- a/bublik/interfaces/api_v2/__init__.py
+++ b/bublik/interfaces/api_v2/__init__.py
@@ -26,6 +26,7 @@ from .management import clear_all_runs_stats_cache, local_logs, meta_categorizat
 from .measurements import MeasurementViewSet
 from .outside_domains import OutsideDomainsViewSet
 from .performance import PerformanceCheckView
+from .report import ReportViewSet
 from .results import ResultViewSet, RunViewSet
 from .server import ServerViewSet
 from .tree import TreeViewSet
@@ -59,4 +60,5 @@ __all__ = [
     'AdminViewSet',
     'PerformanceCheckView',
     'clear_all_runs_stats_cache',
+    'ReportViewSet',
 ]

--- a/bublik/interfaces/api_v2/report.py
+++ b/bublik/interfaces/api_v2/report.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
+
+import logging
+
+from rest_framework import status
+from rest_framework.mixins import RetrieveModelMixin
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from bublik.core.meta.match_references import build_revision_references
+from bublik.core.report.services import (
+    build_report_title,
+    check_report_config,
+    get_report_config_by_id,
+)
+from bublik.core.run.external_links import get_sources
+from bublik.core.shortcuts import build_absolute_uri
+from bublik.data.models import Meta, TestIterationResult
+from bublik.data.serializers import TestIterationResultSerializer
+
+
+logger = logging.getLogger('')
+
+
+__all__ = [
+    'ReportViewSet',
+]
+
+
+class ReportViewSet(RetrieveModelMixin, GenericViewSet):
+    queryset = TestIterationResult.objects.all()
+    serializer_class = TestIterationResultSerializer
+
+    def retrieve(self, request, pk=None):
+        ### Get and check report config ###
+        # check if the config ID has been passed
+        report_config_id = request.query_params.get('config')
+        if not report_config_id:
+            msg = 'report config wasn\'t passed'
+            return Response(
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                data={'message': msg},
+            )
+
+        # check if there is a config of the correct format with the passed config ID
+        report_config = get_report_config_by_id(report_config_id)
+        if not report_config:
+            msg = 'report config is not found or have an incorrect format. JSON is expected'
+            return Response(
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                data={'message': msg},
+            )
+
+        # check if the config has all the necessary keys
+        try:
+            check_report_config(report_config)
+        except KeyError as ke:
+            return Response(
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                data={'message': ke.args[0]},
+            )
+
+        # get the session and the corresponding main package by ID
+        result = self.get_object()
+        main_pkg = result.root
+
+        ### Get common report data ###
+
+        # form the title according to report config
+        title_content = report_config['title_content']
+        title = build_report_title(main_pkg, title_content)
+
+        # get run source link
+        run_source_link = get_sources(main_pkg)
+
+        # get Bublik run stats link
+        run_stats_link = build_absolute_uri(request, f'v2/runs/{main_pkg.id}')
+
+        # get branches
+        meta_branches = Meta.objects.filter(
+            metaresult__result__id=main_pkg.id,
+            type='branch',
+        ).values('name', 'value')
+        branches = meta_branches
+
+        # get revisions
+        meta_revisions = Meta.objects.filter(
+            metaresult__result__id=main_pkg.id,
+            type='revision',
+        ).values('name', 'value')
+        revisions = build_revision_references(meta_revisions)
+
+        ### Collect report data ###
+
+        content = [
+            {
+                'type': 'branch-block',
+                'id': 'branches',
+                'label': 'Branches',
+                'content': branches,
+            },
+            {
+                'type': 'rev-block',
+                'id': 'revisions',
+                'label': 'Revisions',
+                'content': revisions,
+            },
+        ]
+
+        report = {
+            'title': title,
+            'run_source_link': run_source_link,
+            'run_stats_link': run_stats_link,
+            'version': report_config['version'],
+            'content': content,
+        }
+
+        return Response(data=report, status=status.HTTP_200_OK)

--- a/bublik/urls.py
+++ b/bublik/urls.py
@@ -31,6 +31,7 @@ api_v2_router.register(r'session_import', api_v2.EventLogViewSet, 'session_impor
 api_v2_router.register(r'importruns', api_v2.ImportrunsViewSet, 'importruns')
 api_v2_router.register(r'auth/profile', api_v2.ProfileViewSet, 'profile')
 api_v2_router.register(r'auth/admin', api_v2.AdminViewSet, 'admin')
+api_v2_router.register(r'report', api_v2.ReportViewSet, 'report')
 
 ### URL patterns mounting ###
 urlpatterns = [

--- a/templates/settings.py.template
+++ b/templates/settings.py.template
@@ -392,3 +392,26 @@ VIEWS_TIMEOUTS = {
     'history_list_base': 120,
     'history_list_intense': 120,
 }
+
+REPORT_CONFIG_COMPONENTS = {
+    'required_keys': [
+        'id',
+        'name',
+        'description',
+        'version',
+        'title_content',
+        'test_names_order',
+        'tests',
+    ],
+    'required_test_keys': [
+        'table_view',
+        'chart_view',
+        'axis_x',
+        'axis_y',
+        'sequence_group_arg',
+        'percentage_base_value',
+        'sequence_name_conversion',
+        'not_show_args',
+        'records_order',
+    ],
+}


### PR DESCRIPTION
### Info

`ReportViewSet`  have been created. It allows you to build run reports by passed configuration and get a list of run appropriate configurations.

#### Configuration format

Configuration JSON file must include:
- `id`,
- `name`,
- `description`,
- `version`,
- `title_content` (metadata list that will be used in the title),
- `test_names_order` (test names list for tests sorting),
- `tests` (test configurations list).

Test configuration must include:

- `table_view` (flag),
- `chart_view` (flag),
- `axis_x` (test argument),
- `axis_y` (measurement type with a list of measurement names (if you want specific ones) or with an empty list),
- `sequence_group_arg` (test argument that will be used to group the measurement results in a sequences),
- `percentage_base_value` (sequence group argument value, relative to which the percentages will be calculated),
- `sequence_name_conversion` (sequence argument values with corresponding sequences names),
- `not_show_args` (test arguments with their values. The results of the corresponding iterations will not be included in the report.),
- `records_order` (test arguments list for reports sorting).

Example:

```
{
    "id": 1,
    "name": "dpdk-ethdev-ts_base",
    "description": "Base report config for dpdk-ethdev-ts",
    "version": "v1",
    "title_content": [
        "CAMPAIGN_DATE",
        "CFG",
        "SSN",
        "XDP_HW_CSUM",
        "LINK_AGGR"
    ],
    "test_names_order": [
        "testpmd_rxonly"
    ],
    "tests": {
        "testpmd_rxonly": {
            "table_view": true,
            "chart_view": true,
            "axis_x": "packet_size",
            "axis_y": {
                "throughput": []
            },
            "sequence_group_arg": "testpmd_arg_burst",
            "percentage_base_value": 32,
            "sequence_name_conversion": {
                "32": "32 packets",
                "64": "64 packets"
            },
            "not_show_args": {
                "testpmd_command_flow_ctrl_tx": ["off"],
                "n_rx_cores": [1, 4],
                "packet_size": [42, 252, 508, 1514, 2044]
            },
            "records_order": [
                "testpmd_command_flow_ctrl_tx",
                "n_rx_cores",
                "testpmd_arg_rxq"
            ]
        }
    }
}
```

All configurations should be stored next to the project configuration in the `report_configs` folder.

### Usage

Request: `GET /bublik/api/v2/report/<run ID>/configs`

Response data:
```
{
    "run_report_configs": [
        {
            "id": 1,
            "name": "dpdk-ethdev-ts_base",
            "description": "Base report config for dpdk-ethdev-ts"
        },
        {
            "id": 2,
            "name": "dpdk-ethdev-ts_test",
            "description": "Test report config for dpdk-ethdev-ts"
        }
    ],
    "invalid_report_config_files": [
        {
            "file": "dpdk-ethdev-ts_invalid.json",
            "reason": "Invalid format: the key 'test_names_order' is missing"
        },
        {
            "file": "dpdk-ethdev-ts_invalid2.json",
            "reason": "Invalid format: JSON is expected"
        }
    ]
}
```
Request: `GET /bublik/api/v2/report/<run ID>/?config=<configuration ID>`

Response data:

```
{
    "title": "2024-05-19-balin-x710-p0",
    "run_source_link": "https://ts-factory.io/logs/dpdk-ethdev-ts/2024/05/19/balin-x710-p0-cbs-speed-stack-03:00:34/",
    "run_stats_link": "http://localhost/bublik/v2/runs/1",
    "version": "v1",
    "content": [
        {
            "type": "branch-block",
            "id": "branches",
            "label": "Branches",
            "content": [
                {
                    "name": "DPDK_ETHDEV_TS_BRANCH",
                    "value": "main"
                },
                {
                    "name": "TSRIGS_BRANCH",
                    "value": "master"
                },
                {
                    "name": "TSCONF_BRANCH",
                    "value": "main"
                },
                {
                    "name": "DPDK_BRANCH",
                    "value": "next-net-main"
                },
                {
                    "name": "TE_BRANCH",
                    "value": "main"
                }
            ]
        },
        {
            "type": "rev-block",
            "id": "revisions",
            "label": "Revisions",
            "content": [
                {
                    "name": "DPDK_ETHDEV_TS_REV",
                    "value": "4ef0ea5b287151b9d2610dbdb8956dbc54a9609f",
                    "url": ""
                },
                {
                    "name": "TSRIGS_REV",
                    "value": "0fdc96081e6fe5cd48ebfc413a4cffbaf09369a5",
                    "url": ""
                },
                {
                    "name": "TSCONF_REV",
                    "value": "b1dbe598aacbf26268e3137f1ac16ecdaf7953ba",
                    "url": ""
                },
                {
                    "name": "DPDK_REV",
                    "value": "f05a208980caf28174ff7a5d409a1528b86a20bd",
                    "url": ""
                },
                {
                    "name": "TE_REV",
                    "value": "be8fc80d05d6a8eb9b6b54d56eaf60fc884dde0d",
                    "url": "https://git.oktetlabs.ru/git/oktetlabs/test-environment/commit/be8fc80d05d6a8eb9b6b54d56eaf60fc884dde0d"
                }
            ]
        },
        {
            "type": "test-block",
            "id": "testpmd_rxonly",
            "label": "testpmd_rxonly",
            "enable_table_view": true,
            "enable_chart_view": true,
            "common_args": {
                "env": "VAR.env.perf.peer2peer",
                "generator_mode": "txonly",
                "testpmd_arg_forward_mode": "rxonly",
                "testpmd_arg_no_lsc_interrupt": "TRUE",
                "testpmd_arg_rxfreet": 0,
                "testpmd_arg_stats_period": 1
            },
            "content": [
                {
                    "type": "record-entity",
                    "warnings": [],
                    "args_vals": {
                        "testpmd_command_flow_ctrl_tx": "on",
                        "n_rx_cores": 2,
                        "testpmd_arg_rxq": 2
                    },
                    "id": "on-2-2",
                    "label": "on-2-2",
                    "sequence_group_arg": "testpmd_arg_burst",
                    "axis_x_key": "packet_size",
                    "axis_x_label": "packet_size",
                    "axis_y_label": "throughput (bps * 1e+6)",
                    "dataset_table": [
                        [
                            "packet_size",
                            "32 packets",
                            "64 packets",
                            "64 packets gain"
                        ],
                        [
                            60,
                            10000.0,
                            10000.0,
                            0.0
                        ],
                        [
                            124,
                            10000.0,
                            10000.0,
                            0.0
                        ],
                        [
                            1020,
                            10000.0,
                            10000.0,
                            0.0
                        ],
                        [
                            4092,
                            10000.0,
                            10000.0,
                            0.0
                        ],
                        [
                            9014,
                            9999.93,
                            10000.0,
                            0.0
                        ]
                    ],
                    "dataset_chart": [
                        [
                            "packet_size",
                            "32 packets",
                            "64 packets"
                        ],
                        [
                            60,
                            10000.0,
                            10000.0
                        ],
                        [
                            124,
                            10000.0,
                            10000.0
                        ],
                        [
                            1020,
                            10000.0,
                            10000.0
                        ],
                        [
                            4092,
                            10000.0,
                            10000.0
                        ],
                        [
                            9014,
                            9999.93,
                            10000.0
                        ]
                    ]
                },
                {
                    "type": "record-entity",
                    "warnings": [],
                    "args_vals": {
                        "testpmd_command_flow_ctrl_tx": "on",
                        "n_rx_cores": 8,
                        "testpmd_arg_rxq": 8
                    },
                    "id": "on-8-8",
                    "label": "on-8-8",
                    "sequence_group_arg": "testpmd_arg_burst",
                    "axis_x_key": "packet_size",
                    "axis_x_label": "packet_size",
                    "axis_y_label": "throughput (bps * 1e+6)",
                    "dataset_table": [
                        [
                            "packet_size",
                            "32 packets",
                            "64 packets",
                            "64 packets gain"
                        ],
                        [
                            60,
                            10000.0,
                            10000.1,
                            0.0
                        ],
                        [
                            124,
                            10000.0,
                            10000.0,
                            0.0
                        ],
                        [
                            1020,
                            10000.0,
                            10000.0,
                            0.0
                        ],
                        [
                            4092,
                            10000.0,
                            10000.0,
                            0.0
                        ],
                        [
                            9014,
                            10000.0,
                            10000.0,
                            0.0
                        ]
                    ],
                    "dataset_chart": [
                        [
                            "packet_size",
                            "32 packets",
                            "64 packets"
                        ],
                        [
                            60,
                            10000.0,
                            10000.1
                        ],
                        [
                            124,
                            10000.0,
                            10000.0
                        ],
                        [
                            1020,
                            10000.0,
                            10000.0
                        ],
                        [
                            4092,
                            10000.0,
                            10000.0
                        ],
                        [
                            9014,
                            10000.0,
                            10000.0
                        ]
                    ]
                }
            ]
        }
    ]
}
```