### PR TITLE
Deploy: make deploy more flexible

### DIFF
--- a/scripts/deploy
+++ b/scripts/deploy
@@ -196,7 +196,7 @@ function install_server_packages() {
     sqlite3
     nginx
     virtualenv
-    postgresql-client-13
+    postgresql-client
     python3-setuptools
     libkrb5-dev
     mercurial


### PR DESCRIPTION
We have no strict requirements on postgresql version in fact. Various versions work fine. Avoid version specification in deploy scripts to make it unnecessary to update the script on distro version update.