### PR TITLE
Settings: fix import of settings

### DIFF
--- a/bublik/core/mail.py
+++ b/bublik/core/mail.py
@@ -11,7 +11,6 @@ from django.utils.http import urlsafe_base64_encode
 import per_conf
 
 from bublik.core.shortcuts import build_absolute_uri
-from bublik.settings import EMAIL_FROM
 
 
 def send_importruns_failed_mail(
@@ -70,6 +69,8 @@ def send_verification_link_mail(request, user):
     '''
     Sends an email to the user with a link that activates his account when clicked.
     '''
+    from_email = getattr(settings, 'EMAIL_FROM', None)
+
     email_verification_token = EmailVerificationTokenGenerator()
     user_id_b64 = urlsafe_base64_encode(force_bytes(user.pk))
     token = email_verification_token.make_token(user)
@@ -81,6 +82,6 @@ def send_verification_link_mail(request, user):
     send_mail(
         subject='Verify email',
         message=f'Click the following link to verify your email: {verify_email_link}',
-        from_email=EMAIL_FROM,
+        from_email=from_email,
         recipient_list=[user.email],
     )

--- a/bublik/core/report/services.py
+++ b/bublik/core/report/services.py
@@ -7,10 +7,10 @@ from itertools import groupby
 import json
 import os
 
-from bublik import settings
+from django.conf import settings
+
 from bublik.core.utils import get_metric_prefix_units
 from bublik.data.models import MeasurementResult, Meta, TestArgument
-from bublik.settings import REPORT_CONFIG_COMPONENTS
 
 
 def get_report_config():
@@ -40,14 +40,23 @@ def check_report_config(report_config):
     '''
     Check the passed report config for compliance with the expected format.
     '''
-    for key in REPORT_CONFIG_COMPONENTS['required_keys']:
+    try:
+        report_config_components = settings.REPORT_CONFIG_COMPONENTS
+    except AttributeError as ae:
+        msg = ("The key 'REPORT_CONFIG_COMPONENTS' is missing in the settings. "
+               "Take the 'django_settings' deployment step.")
+        raise AttributeError(
+            msg,
+        ) from ae
+
+    for key in report_config_components['required_keys']:
         if key not in report_config.keys():
             msg = f'the required key \'{key}\' is missing in the configuration'
             raise KeyError(msg)
 
-    possible_axis_y_keys = REPORT_CONFIG_COMPONENTS['possible_axis_y_keys']
+    possible_axis_y_keys = report_config_components['possible_axis_y_keys']
     for test_name, test_configuration in report_config['tests'].items():
-        for key in REPORT_CONFIG_COMPONENTS['required_test_keys']:
+        for key in report_config_components['required_test_keys']:
             if key not in test_configuration.keys():
                 msg = (
                     f'the required key \'{key}\' is missing for \'{test_name}\' '

--- a/bublik/interfaces/api_v2/auth.py
+++ b/bublik/interfaces/api_v2/auth.py
@@ -3,6 +3,7 @@
 
 from functools import wraps
 
+from django.conf import settings
 from django.contrib.auth import authenticate
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.mail import send_mail
@@ -33,7 +34,6 @@ from bublik.data.serializers import (
     UserEmailSerializer,
     UserSerializer,
 )
-from bublik.settings import EMAIL_FROM, SIMPLE_JWT
 
 
 __all__ = [
@@ -50,8 +50,8 @@ __all__ = [
 
 def get_user_info_from_access_token(access_token):
     token_backend = TokenBackend(
-        algorithm=SIMPLE_JWT['ALGORITHM'],
-        signing_key=SIMPLE_JWT['SIGNING_KEY'],
+        algorithm=settings.SIMPLE_JWT['ALGORITHM'],
+        signing_key=settings.SIMPLE_JWT['SIGNING_KEY'],
     )
     return token_backend.decode(access_token, verify=True)
 
@@ -395,7 +395,7 @@ class ForgotPasswordView(generics.CreateAPIView):
         send_mail(
             subject='Password Reset',
             message=f'Click the following link to reset your password: {reset_link}',
-            from_email=EMAIL_FROM,
+            from_email=settings.EMAIL_FROM,
             recipient_list=[user.email],
         )
 

--- a/bublik/interfaces/api_v2/server.py
+++ b/bublik/interfaces/api_v2/server.py
@@ -1,14 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
+from django.conf import settings
 import per_conf
 
 from rest_framework.decorators import action
 from rest_framework.mixins import RetrieveModelMixin
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
-
-from bublik.settings import REPO_REVISIONS
 
 
 __all__ = [
@@ -26,5 +25,5 @@ class ServerViewSet(RetrieveModelMixin, GenericViewSet):
 
     @action(detail=False, methods=['get'])
     def version(self, request):
-        data = REPO_REVISIONS
+        data = settings.REPO_REVISIONS
         return Response(data=data)

--- a/bublik/interfaces/management/commands/add_tags.py
+++ b/bublik/interfaces/management/commands/add_tags.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import tempfile
 
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.management.base import BaseCommand
 import pytz
@@ -26,7 +27,6 @@ from bublik.core.importruns.telog import JSONLog
 from bublik.core.run.objects import add_tags
 from bublik.core.url import save_url_to_dir
 from bublik.data.models import MetaResult, TestIterationResult
-from bublik.settings import TIME_ZONE
 
 
 logger = logging.getLogger('bublik.server')
@@ -131,7 +131,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options) -> None:
         logger.info('Running a command to add tags.')
-        start_time = datetime.now(tz=pytz.timezone(TIME_ZONE))
+        start_time = datetime.now(tz=pytz.timezone(settings.TIME_ZONE))
 
         # Get the base url that is the same for all runs
         log_base_url = options['log_base']
@@ -153,12 +153,12 @@ class Command(BaseCommand):
             from_date = datetime.combine(
                 date=options['from'].date(),
                 time=options['from'].time(),
-                tzinfo=pytz.timezone(TIME_ZONE),
+                tzinfo=pytz.timezone(settings.TIME_ZONE),
             )
             to_date = datetime.combine(
                 date=options['to'].date(),
                 time=options['to'].time(),
-                tzinfo=pytz.timezone(TIME_ZONE),
+                tzinfo=pytz.timezone(settings.TIME_ZONE),
             )
 
             logger.debug(f'The starting date of updating tags is {from_date}.')
@@ -177,16 +177,16 @@ class Command(BaseCommand):
                 return
 
         for run in runs:
-            log_processing_start_time = datetime.now(tz=pytz.timezone(TIME_ZONE))
+            lp_start_time = datetime.now(tz=pytz.timezone(settings.TIME_ZONE))
             try:
                 Command.process_log_and_update_tags(run=run, log_base_url=log_base_url)
             except ObjectDoesNotExist:
                 continue
             logger.info(
                 f'Adding tags for run {run.pk} is completed in '
-                f'{datetime.now(tz=pytz.timezone(TIME_ZONE)) - log_processing_start_time}',
+                f'{datetime.now(tz=pytz.timezone(settings.TIME_ZONE)) - lp_start_time}',
             )
 
         logger.info(
-            f'Completed in {datetime.now(tz=pytz.timezone(TIME_ZONE)) - start_time}.',
+            f'Completed in {datetime.now(tz=pytz.timezone(settings.TIME_ZONE)) - start_time}.',
         )


### PR DESCRIPTION
Importing settings from django.conf is preferable because django.conf contains a more complete set of settings, including both project settings and Django settings.