### PR TITLE
Report: update and fix

### DIFF
--- a/bublik/core/report/components.py
+++ b/bublik/core/report/components.py
@@ -188,7 +188,7 @@ class ReportRecord:
         percentage_base_value = test_config['percentage_base_value']
         percentage_base_value = sequence_name_conversion(percentage_base_value, test_config)
 
-        if percentage_base_value is not None:
+        if percentage_base_value not in ['', 'None']:
             if percentage_base_value in dataset_labels:
                 self.formatters = {}
                 pbv_idx = dataset_labels.index(percentage_base_value)

--- a/bublik/core/report/components.py
+++ b/bublik/core/report/components.py
@@ -81,7 +81,7 @@ class ReportMeasurementLevel:
     to the measurements and include datasets.
     '''
 
-    def __init__(self, record_info, record_points, test_name, report_config):
+    def __init__(self, test_name, av_lvl_id, record_info, record_points, report_config):
         test_config = report_config['tests'][test_name]
         table_view = test_config['table_view']
         chart_view = test_config['chart_view']
@@ -92,7 +92,7 @@ class ReportMeasurementLevel:
         self.axis_x_key = test_config['axis_x']
         self.axis_x_label = test_config['axis_x']
         self.axis_y_label = record_info
-        self.id = self.axis_y_label
+        self.id = '_'.join([av_lvl_id, self.axis_y_label.replace(' ', '')])
 
         if table_view or chart_view:
             # group points into sequences
@@ -218,11 +218,11 @@ class ReportArgsValsLevel:
     and their values.
     '''
 
-    def __init__(self, arg_val_record_points, test_name, report_config):
+    def __init__(self, test_name, test_lvl_id, arg_val_record_points, report_config):
         self.type = 'arg-val-block'
         self.args_vals = arg_val_record_points[0].args_vals
         self.label = self.build_label()
-        self.id = self.label
+        self.id = '_'.join([test_lvl_id, self.label.replace(' ', '')])
         self.content = []
 
         arg_val_record_points = sorted(
@@ -235,9 +235,10 @@ class ReportArgsValsLevel:
             ReportPoint.points_grouper_measurements,
         ):
             axis_y_record = ReportMeasurementLevel(
+                test_name,
+                self.id,
                 axis_y_record_info,
                 list(axis_y_record_points),
-                test_name,
                 report_config,
             )
             self.content.append(axis_y_record.__dict__)
@@ -281,8 +282,9 @@ class ReportTestLevel:
             ReportPoint.points_grouper_args_vals,
         ):
             arg_val_record = ReportArgsValsLevel(
-                list(arg_val_record_points),
                 test_name,
+                self.id,
+                list(arg_val_record_points),
                 report_config,
             )
             self.content.append(arg_val_record.__dict__)

--- a/bublik/core/report/services.py
+++ b/bublik/core/report/services.py
@@ -54,8 +54,8 @@ def check_report_config(report_config):
                     'test in the configuration'
                 )
                 raise KeyError(msg)
-        for _, meas_params in test_configuration['axis_y'].items():
-            for meas_param in meas_params:
+        for measurement in test_configuration['axis_y']:
+            for meas_param in measurement:
                 if meas_param not in possible_axis_y_keys:
                     payk_str = ', '.join(f'\'{key}\'' for key in possible_axis_y_keys)
                     msg = (
@@ -211,34 +211,37 @@ def filter_by_axis_y(mmrs_test, axis_y):
     Filter passed measurement results QS by axis y value from config.
     '''
     axis_y_mmrs = MeasurementResult.objects.none()
-    for meas_type, meas_type_details in axis_y.items():
-        meas_mmrs = mmrs_test.filter(
-            measurement__metas__name='type',
-            measurement__metas__type='measurement_subject',
-            measurement__metas__value=meas_type,
-        )
+    for measurement in axis_y:
+        # filter by tool
+        if 'tool' in measurement:
+            tools = measurement.pop('tool')
+            mmrs_test = mmrs_test.filter(
+                measurement__metas__name='tool',
+                measurement__metas__type='tool',
+                measurement__metas__value__in=tools,
+            )
 
-        if 'keys' in meas_type_details:
+        # filter by keys
+        if 'keys' in measurement:
             meas_key_mmrs = MeasurementResult.objects.none()
-            keys_vals = meas_type_details.pop('keys')
+            keys_vals = measurement.pop('keys')
             for key_name, key_vals in keys_vals.items():
-                meas_key_mmrs_group = meas_mmrs.filter(
+                meas_key_mmrs_group = mmrs_test.filter(
                     measurement__metas__name=key_name,
                     measurement__metas__type='measurement_key',
                     measurement__metas__value__in=key_vals,
                 )
                 meas_key_mmrs = meas_key_mmrs.union(meas_key_mmrs_group)
-            meas_mmrs = meas_key_mmrs
+            mmrs_test = meas_key_mmrs
 
-        for meas_detail, meas_detail_vals in meas_type_details.items():
-            meas_mmrs = meas_mmrs.filter(
-                measurement__metas__name=meas_detail,
+        # filter by measurement subjects (type, name, aggr)
+        for ms, ms_values in measurement.items():
+            mmrs_test = mmrs_test.filter(
+                measurement__metas__name=ms,
                 measurement__metas__type='measurement_subject',
-                measurement__metas__value__in=meas_detail_vals,
+                measurement__metas__value__in=ms_values,
             )
-
-        axis_y_mmrs = axis_y_mmrs.union(meas_mmrs)
-
+        axis_y_mmrs = axis_y_mmrs.union(mmrs_test)
     return axis_y_mmrs
 
 

--- a/bublik/interfaces/api_v2/report.py
+++ b/bublik/interfaces/api_v2/report.py
@@ -174,7 +174,7 @@ class ReportViewSet(RetrieveModelMixin, GenericViewSet):
             mmrs_test = filter_by_axis_y(mmrs_test, axis_y)
             if not mmrs_test:
                 msg = (
-                    f'incorrect value \'{axis_y}\' for \'axis_y\' key for \'{test_name}\' '
+                    f'incorrect value for \'axis_y\' key for \'{test_name}\' '
                     'test in the report config'
                 )
                 return Response(

--- a/bublik/interfaces/api_v2/report.py
+++ b/bublik/interfaces/api_v2/report.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from bublik.core.meta.match_references import build_revision_references
-from bublik.core.report.components import ReportPoint, ReportTest
+from bublik.core.report.components import ReportPoint, ReportTestLevel
 from bublik.core.report.services import (
     args_type_convesion,
     build_report_title,
@@ -258,7 +258,7 @@ class ReportViewSet(RetrieveModelMixin, GenericViewSet):
         point_groups_by_test_name = args_type_convesion(point_groups_by_test_name)
 
         for test_name, test_points in point_groups_by_test_name.items():
-            test = ReportTest(test_name, common_args, list(test_points), report_config)
+            test = ReportTestLevel(test_name, common_args, list(test_points), report_config)
             test_records.append(test.__dict__)
 
         ### Collect report data ###

--- a/doc/wiki/report_config.json
+++ b/doc/wiki/report_config.json
@@ -18,17 +18,21 @@
             "table_view": true,
             "chart_view": true,
             "axis_x": "packet_size",
-            "axis_y": {
-                "throughput": {
-                    "name": [],
-                    "aggr": [
-                        "mean"
+            "axis_y": [
+                {
+                    "type": [
+                        "throughput"
                     ],
                     "keys": {
-                        "Side":"Rx"
-                    }
+                        "Side": [
+                            "Rx"
+                        ]
+                    },
+                    "aggr": [
+                        "mean"
+                    ]
                 }
-            },
+            ],
             "sequence_group_arg": "testpmd_arg_burst",
             "percentage_base_value": 32,
             "sequence_name_conversion": {

--- a/doc/wiki/reports.md
+++ b/doc/wiki/reports.md
@@ -22,7 +22,7 @@ Test configuration must include:
 - 'table_view' (flag),
 - 'chart_view' (flag),
 - 'axis_x' (test argument),
-- 'axis_y' (measurement type with a dictionary of measurement parameters ('name', 'aggr', 'keys') and their values to use),
+- 'axis_y' (list of dictionaries, the keys of which are measurement parameters ('tool', 'type', 'name', 'keys', 'aggr'), and the values are lists (dictionaries for 'keys') of their values),
 - 'sequence_group_arg' (test argument that will be used to group the measurement results in a sequences),
 - 'percentage_base_value' (sequence group argument value, relative to which the percentages will be calculated),
 - 'sequence_name_conversion' (sequence argument values with corresponding sequences names),

--- a/templates/settings.py.template
+++ b/templates/settings.py.template
@@ -415,8 +415,10 @@ REPORT_CONFIG_COMPONENTS = {
         'records_order',
     ],
     'possible_axis_y_keys': [
+        'tool',
+        'type',
         'name',
-        'aggr',
         'keys',
+        'aggr',
     ],
 }


### PR DESCRIPTION
1. Fix empty percentage base value and invalid iterations handling
2. Expand possibilities of measurement setting by changing the report config structure
3. Update the report content structure to avoid duplication of common data
4. Ensure the uniqueness of IDs throughout the report