### PR TITLE
Add configs management

### DIFF
--- a/bublik/core/config/filters.py
+++ b/bublik/core/config/filters.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
+
+from copy import deepcopy
+
+from django.db.models import JSONField
+from django_filters import filterset
+from django_filters.rest_framework import FilterSet
+from django_filters.rest_framework.filters import CharFilter
+
+
+class ConfigFilter(FilterSet):
+    FILTER_DEFAULTS = deepcopy(filterset.FILTER_FOR_DBFIELD_DEFAULTS)
+    FILTER_DEFAULTS.update(
+        {
+            JSONField: {
+                'filter_class': CharFilter,
+                'extra': lambda f: {'lookup_expr': ['icontains']},
+            },
+        },
+    )

--- a/bublik/core/config/services.py
+++ b/bublik/core/config/services.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
+
+import logging
+
+import per_conf
+
+from bublik.core.checks import check_per_conf
+from bublik.data.models import Config
+
+
+logger = logging.getLogger('bublik.server')
+
+
+def getattr_from_per_conf(data_key, default=None, required=False):
+    per_conf_obj = Config.get_current_version('global', 'per_conf')
+    if not per_conf_obj:
+        logger.warning(
+            'You need to move the contents of per_conf.py to the DB by creating '
+            'a global per_conf config object',
+        )
+        if required and not check_per_conf(data_key, logger):
+            raise AttributeError
+        return getattr(per_conf, data_key, default)
+    if data_key in per_conf_obj.content:
+        return per_conf_obj.content[data_key]
+    if required:
+        msg = f"'{data_key}' wasn\'t found in per_conf global config object"
+        raise KeyError(msg)
+    return default

--- a/bublik/core/mail.py
+++ b/bublik/core/mail.py
@@ -8,8 +8,8 @@ from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.core.mail import send_mail
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
-import per_conf
 
+from bublik.core.config.services import getattr_from_per_conf
 from bublik.core.shortcuts import build_absolute_uri
 
 
@@ -29,7 +29,7 @@ def send_importruns_failed_mail(
     '''
 
     email_from = getattr(settings, 'EMAIL_FROM', None)
-    recipients = getattr(per_conf, 'EMAIL_PROJECT_WATCHERS', []) + getattr(
+    recipients = getattr_from_per_conf('EMAIL_PROJECT_WATCHERS', default=[]) + getattr(
         settings,
         'EMAIL_ADMINS',
         [],

--- a/bublik/core/report/services.py
+++ b/bublik/core/report/services.py
@@ -4,74 +4,11 @@
 import contextlib
 
 from itertools import groupby
-import json
-import os
 
 from django.conf import settings
 
 from bublik.core.utils import get_metric_prefix_units
 from bublik.data.models import MeasurementResult, Meta, TestArgument
-
-
-def get_report_config():
-    report_configs_dir = os.path.join(settings.PER_CONF_DIR, 'reports')
-    for root, _, report_config_files in os.walk(report_configs_dir):
-        for report_config_file in report_config_files:
-            with open(os.path.join(root, report_config_file)) as rcf:
-                try:
-                    report_config = json.load(rcf)
-                    yield report_config_file, report_config
-                except json.decoder.JSONDecodeError:
-                    yield report_config_file, None
-
-
-def get_report_config_by_id(report_config_id):
-    for _, report_config in get_report_config():
-        if report_config:
-            try:
-                if str(report_config['id']) == report_config_id:
-                    return report_config
-            except KeyError:
-                continue
-    return None
-
-
-def check_report_config(report_config):
-    '''
-    Check the passed report config for compliance with the expected format.
-    '''
-    try:
-        report_config_components = settings.REPORT_CONFIG_COMPONENTS
-    except AttributeError as ae:
-        msg = ("The key 'REPORT_CONFIG_COMPONENTS' is missing in the settings. "
-               "Take the 'django_settings' deployment step.")
-        raise AttributeError(
-            msg,
-        ) from ae
-
-    for key in report_config_components['required_keys']:
-        if key not in report_config.keys():
-            msg = f'the required key \'{key}\' is missing in the configuration'
-            raise KeyError(msg)
-
-    possible_axis_y_keys = report_config_components['possible_axis_y_keys']
-    for test_name, test_configuration in report_config['tests'].items():
-        for key in report_config_components['required_test_keys']:
-            if key not in test_configuration.keys():
-                msg = (
-                    f'the required key \'{key}\' is missing for \'{test_name}\' '
-                    'test in the configuration'
-                )
-                raise KeyError(msg)
-        for measurement in test_configuration['axis_y']:
-            for meas_param in measurement:
-                if meas_param not in possible_axis_y_keys:
-                    payk_str = ', '.join(f'\'{key}\'' for key in possible_axis_y_keys)
-                    msg = (
-                        f'unsupported measurement parameter \'{meas_param}\' for '
-                        f'\'{test_name}\' test in the configuration. Possible are {payk_str}'
-                    )
-                    raise KeyError(msg)
 
 
 def build_report_title(main_pkg, title_content):

--- a/bublik/core/run/data.py
+++ b/bublik/core/run/data.py
@@ -4,8 +4,8 @@
 from collections import OrderedDict, defaultdict
 
 from django.core.cache import caches
-import per_conf
 
+from bublik.core.config.services import getattr_from_per_conf
 from bublik.core.meta.categorization import (
     get_metas_by_category,
     group_by_runs,
@@ -26,7 +26,7 @@ def get_metadata_by_runs(runs, categorize=False):
         'meta__id',
     )
 
-    metadata_categories = getattr(per_conf, 'METADATA_ON_PAGES', [])
+    metadata_categories = getattr_from_per_conf('METADATA_ON_PAGES', default=[])
 
     groupping_kwargs = {
         'meta_results': metadata_results,

--- a/bublik/core/run/objects.py
+++ b/bublik/core/run/objects.py
@@ -6,8 +6,8 @@ import logging
 
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db.models import Count
-import per_conf
 
+from bublik.core.config.services import getattr_from_per_conf
 from bublik.core.meta.categorization import categorize_meta
 from bublik.core.run.keys import prepare_expected_key
 from bublik.core.run.utils import prepare_date
@@ -259,8 +259,8 @@ def run_status_default(status_key):
 
 
 def set_run_status(run, status_key):
-    status_meta_name = getattr(per_conf, 'RUN_STATUS_META', None)
-    status_value = getattr(per_conf, status_key, run_status_default(status_key))
+    status_meta_name = getattr_from_per_conf('RUN_STATUS_META')
+    status_value = getattr_from_per_conf(status_key, default=run_status_default(status_key))
     if status_meta_name:
         update_or_create_meta_result(
             m_data={

--- a/bublik/core/run/stats.py
+++ b/bublik/core/run/stats.py
@@ -8,11 +8,10 @@ import sys
 
 from django.conf import settings
 from django.db.models import Exists, F, OuterRef, Q
-import per_conf
-
 from references import References
 
 from bublik.core.cache import RunCache
+from bublik.core.config.services import getattr_from_per_conf
 from bublik.core.datetime_formatting import (
     display_to_date_in_numbers,
     display_to_seconds,
@@ -657,7 +656,7 @@ def generate_result_details(test_result):
 
 
 def get_run_status(run):
-    status_meta_name = getattr(per_conf, 'RUN_STATUS_META', None)
+    status_meta_name = getattr_from_per_conf('RUN_STATUS_META')
     status_meta = MetaResult.objects.filter(result=run, meta__name=status_meta_name).first()
     if status_meta:
         return status_meta.meta.value
@@ -694,7 +693,7 @@ def generate_all_run_details(run):
     run_id = run.id
     conclusion, conclusion_reason = get_run_conclusion(run)
     important_tags, relevant_tags = get_tags_by_runs([run_id])
-    category_names = getattr(per_conf, 'SPECIAL_CATEGORIES', [])
+    category_names = getattr_from_per_conf('SPECIAL_CATEGORIES', default=[])
     run_meta_results = run.meta_results.select_related('meta')
     q = MetaResultsQuery(run_meta_results)
 

--- a/bublik/data/managers/result.py
+++ b/bublik/data/managers/result.py
@@ -4,8 +4,8 @@
 from datetime import datetime
 
 from django.db.models import Manager, Q, QuerySet
-import per_conf
 
+from bublik.core.config.services import getattr_from_per_conf
 from bublik.data.managers.utils import create_metas_query
 from bublik.data.models.meta import Meta
 
@@ -27,7 +27,7 @@ It doesn`t have to return a QuerySet.
 
 class TestIterationResultQuerySet(QuerySet):
     def filter_by_run_status(self, run_status):
-        status_meta_name = getattr(per_conf, 'RUN_STATUS_META', None)
+        status_meta_name = getattr_from_per_conf('RUN_STATUS_META')
         return self.filter(
             meta_results__meta__name=status_meta_name,
             meta_results__meta__value=run_status,

--- a/bublik/data/models/__init__.py
+++ b/bublik/data/models/__init__.py
@@ -21,6 +21,7 @@ The database is capable to keep thousands of test runs which contain thousands
 of test iteration results.
 '''
 
+from .config import Config, ConfigTypes, GlobalConfigNames
 from .endpoint_url import EndpointURL
 from .eventlog import EventLog
 from .expectation import Expectation, ExpectMeta
@@ -81,4 +82,7 @@ __all__ = [
     'UserManager',
     'UserRoles',
     'EndpointURL',
+    'ConfigTypes',
+    'GlobalConfigNames',
+    'Config',
 ]

--- a/bublik/data/models/config.py
+++ b/bublik/data/models/config.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
+
+from enum import Enum
+
+from django.db import models
+
+from bublik.data.models.user import User
+
+
+__all__ = [
+    'ConfigTypes',
+    'GlobalConfigNames',
+    'Config',
+]
+
+
+class ConfigTypes(models.TextChoices):
+    '''
+    All available configuration types.
+    '''
+
+    GLOBAL = 'global'
+    REPORT = 'report'
+
+
+class GlobalConfigNames(str, Enum):
+    '''
+    All available global configuration names.
+    '''
+
+    PER_CONF = 'per_conf'
+
+    def __str__(self):
+        return self.value
+
+    @classmethod
+    def all(cls):
+        return [value.value for name, value in vars(cls).items() if name.isupper()]
+
+
+class Config(models.Model):
+    '''
+    Configurations.
+    '''
+
+    created = models.DateTimeField(help_text='Timestamp of the config creation.')
+    type = models.CharField(
+        choices=ConfigTypes.choices,
+        max_length=16,
+        help_text='Configuration type.',
+    )
+    name = models.TextField(max_length=32, help_text='Configuration name.')
+    version = models.IntegerField(default=0, help_text='Configuration version.')
+    is_current = models.BooleanField(default=True)
+    description = models.TextField(
+        blank=True,
+        help_text='Description of the configuration.',
+    )
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name='config',
+        help_text='The user who created the configuration object.',
+    )
+    content = models.JSONField(help_text='Configuration data.')
+
+    class Meta:
+        db_table = 'bublik_config'
+        unique_together = ('type', 'name', 'version')
+
+    @classmethod
+    def get_latest_version(cls, config_type, config_name):
+        return (
+            Config.objects.filter(type=config_type, name=config_name).order_by('version').last()
+        )
+
+    @classmethod
+    def get_current_version(cls, config_type, config_name):
+        return Config.objects.filter(
+            type=config_type,
+            name=config_name,
+            is_current=True,
+        ).first()
+
+    def delete(self, *args, **kwargs):
+        if self.is_current:
+            config_type = self.type
+            config_name = self.name
+            super().delete(*args, **kwargs)
+            latest = self.get_latest_version(config_type, config_name)
+            if latest:
+                latest.is_current = True
+                latest.save()
+        else:
+            super().delete(*args, **kwargs)
+
+    def __repr__(self):
+        return (
+            f'Config(created={self.created!r}, type={self.type!r}, name={self.name!r}, '
+            f'version={self.version!r}, is_current={self.is_current!r}, '
+            f'description={self.description!r}, user={self.user!r})'
+        )

--- a/bublik/data/models/result.py
+++ b/bublik/data/models/result.py
@@ -5,8 +5,8 @@ from itertools import chain
 
 from django.db import models
 from django.utils.functional import cached_property
-import per_conf
 
+from bublik.core.config.services import getattr_from_per_conf
 from bublik.core.queries import MetaResultsQuery, get_or_none
 from bublik.core.utils import get_difference
 from bublik.data.managers import TestIterationResultManager
@@ -64,7 +64,10 @@ class RunStatusByUnexpected:
         total = run_stats['total']
         unexpected = run_stats['unexpected']
         unexpected_percent = round(unexpected / total * 100) if total else 0
-        left_border, right_border = getattr(per_conf, 'RUN_STATUS_BY_NOK_BORDERS', (20.0, 80.0))
+        left_border, right_border = getattr_from_per_conf(
+            'RUN_STATUS_BY_NOK_BORDERS',
+            default=(20.0, 80.0),
+        )
 
         if total == 0 or unexpected_percent >= right_border:
             return cls.ERROR, unexpected_percent
@@ -112,7 +115,7 @@ class RunConclusion:
             RunStatus.STOPPED: cls.STOPPED,
             RunStatus.BUSY: cls.BUSY,
         }
-        run_status_meta = per_conf.RUN_STATUS_META
+        run_status_meta = getattr_from_per_conf('RUN_STATUS_META', required=True)
         if run_status in conclusions_by_statuses:
             reason = f'{run_status_meta} reported by TE is {run_status}'
             return conclusions_by_statuses[run_status], reason

--- a/bublik/data/schemas/per_conf.json
+++ b/bublik/data/schemas/per_conf.json
@@ -1,0 +1,179 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "PROJECT": {
+            "description": "Identifies project matching PROJECT meta in metadata.json",
+            "type": "string"
+        },
+        "EMAIL_PROJECT_WATCHERS": {
+            "description": "List of emails to notify about importruns failures",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "DASHBOARD_HEADER": {
+            "description": "Sets columns on dashboard",
+            "type": "object",
+            "additionalProperties": {
+                "type": "string",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "DASHBOARD_PAYLOAD": {
+            "description": "Sets link available by click on column values",
+            "type": "object",
+            "additionalProperties": {
+                "type": "string",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "DASHBOARD_DATE": {
+            "description": "Represents the name of the meta pointing to which date the run is related to",
+            "type": "string"
+        },
+        "DASHBOARD_RUNS_SORT": {
+            "description": "Represents a list of DASHBOARD_HEADER keys and extra 'start' key which defines run start",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "DASHBOARD_DEFAULT_MODE": {
+            "description": "Sets the mode (one_day_one_column/one_day_two_columns/two_days_two_columns) which dashboard follows when opens",
+            "type": "string"
+        },
+        "METADATA_ON_PAGES": {
+            "description": "Represents a list of meta category names that manages columns in the history and runs page",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "SPECIAL_CATEGORIES": {
+            "description": "Represents a list of meta category names that defines extra data to show in Info block on run and log pages",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "RUN_STATUS_META": {
+            "description": "Represents meta name in meta_data.json that defines run status",
+            "type": "string"
+        },
+        "RUN_STATUS_BY_NOK_BORDERS": {
+            "description": "Represents 2 float numbers (left and right borders) that sets borders for defining run status by rate of unexpected results",
+            "type": "array",
+            "items": {
+                "type": "number"
+            },
+            "uniqueItems": true,
+            "minItems": 2,
+            "maxItems": 2
+        },
+        "RUN_COMPLETE_FILE": {
+            "description": "Represents file available via run source link that indicates that run testing was completed",
+            "type": "string"
+        },
+        "RUN_KEY_METAS": {
+            "description": "Represents meta name in meta_data.json that allows Bublik to distinguish one run from another",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "FILES_TO_GENERATE_METADATA": {
+            "description": "Represents a list of files available via run source link and allows Bublik to generate meta_data.json based on them",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "CSRF_TRUSTED_ORIGINS": {
+            "description": "Domens which Bublik server trusts accepting requests coming from",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "HISTORY_SEARCH_EXAMPLE": {
+            "description": "An example of history search for performance checking",
+            "type": "object",
+            "properties": {
+                "testName": {
+                    "type": "string"
+                },
+                "startDate": {
+                    "type": "string"
+                },
+                "finishDate": {
+                    "type": "string"
+                },
+                "runData": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "string"
+                },
+                "labels": {
+                    "type": "string"
+                },
+                "revisions": {
+                    "type": "string"
+                },
+                "branches": {
+                    "type": "string"
+                },
+                "testArgs": {
+                    "type": "string"
+                },
+                "verdict": {
+                    "type": "string"
+                },
+                "tagExpr": {
+                    "type": "string"
+                },
+                "labelExpr": {
+                    "type": "string"
+                },
+                "revisionExpr": {
+                    "type": "string"
+                },
+                "branchExpr": {
+                    "type": "string"
+                },
+                "testArgExpr": {
+                    "type": "string"
+                },
+                "verdictExpr": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "testName",
+                "startDate",
+                "finishDate"
+            ]
+        }
+    },
+    "required": [
+        "PROJECT",
+        "RUN_STATUS_META",
+        "RUN_KEY_METAS",
+        "DASHBOARD_HEADER",
+        "RUN_COMPLETE_FILE"
+    ],
+    "additionalProperties": false
+}

--- a/bublik/data/schemas/report.json
+++ b/bublik/data/schemas/report.json
@@ -1,0 +1,136 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "title_content": {
+            "description": "Metas for title genegation",
+            "type": "array",
+            "items": {
+                "description": "Meta with label type",
+                "type": "string"
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "test_names_order": {
+            "description": "Test names for tests sorting",
+            "type": "array",
+            "items": {
+                "description": "Test name",
+                "type": "string"
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "tests": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "table_view": {
+                        "description": "Table view flag",
+                        "type": "boolean"
+                    },
+                    "chart_view": {
+                        "description": "Chart view flag",
+                        "type": "boolean"
+                    },
+                    "axis_x": {
+                        "description": "Axis x test argument",
+                        "type": "string",
+                        "minLength": 2
+                    },
+                    "axis_y": {
+                        "description": "Measurement parameters",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "tool": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "name": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "aggr": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "keys": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "sequence_group_arg": {
+                        "description": "Sequence group argument",
+                        "type": "string"
+                    },
+                    "percentage_base_value": {
+                        "description": "Base value for percentage calculation",
+                        "type": ["string", "number", "null"]
+                    },
+                    "sequence_name_conversion": {
+                        "type": "object",
+                        "additionalProperties": true
+                    },
+                    "not_show_args": {
+                        "description": "Arguments and their values for excluding results from the report",
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "records_order": {
+                        "description": "Test names list for records sorting",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "table_view",
+                    "chart_view",
+                    "axis_x",
+                    "axis_y",
+                    "sequence_group_arg",
+                    "percentage_base_value",
+                    "sequence_name_conversion",
+                    "not_show_args",
+                    "records_order"
+                ]
+            }
+        }
+    },
+    "required": [
+        "title_content",
+        "test_names_order",
+        "tests"
+    ],
+    "additionalProperties": false
+}

--- a/bublik/data/schemas/services.py
+++ b/bublik/data/schemas/services.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
+
+import json
+import os
+
+
+SCHEMAS_DIR = os.path.dirname(__file__)
+
+
+def load_schema(schema_name):
+    with open(os.path.join(SCHEMAS_DIR, f'{schema_name}.json')) as schema_file:
+        return json.load(schema_file)

--- a/bublik/data/serializers/__init__.py
+++ b/bublik/data/serializers/__init__.py
@@ -9,6 +9,7 @@ from .auth import (
     UserEmailSerializer,
     UserSerializer,
 )
+from .config import ConfigSerializer
 from .endpoint_url import EndpointURLSerializer
 from .eventlog import EventLogSerializer
 from .expectation import (
@@ -56,4 +57,5 @@ __all__ = [
     'PasswordResetSerializer',
     'UpdateUserSerializer',
     'EndpointURLSerializer',
+    'ConfigSerializer',
 ]

--- a/bublik/data/serializers/config.py
+++ b/bublik/data/serializers/config.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
+
+from datetime import datetime
+import json
+
+import jsonschema
+
+from jsonschema import validate
+from rest_framework import serializers
+from rest_framework.serializers import ModelSerializer
+
+from bublik.core.auth import get_user_by_access_token
+from bublik.core.queries import get_or_none
+from bublik.core.run.utils import prepare_date
+from bublik.data.models import Config, ConfigTypes, GlobalConfigNames
+from bublik.data.schemas.services import load_schema
+
+
+__all__ = [
+    'ConfigSerializer',
+]
+
+
+class ConfigSerializer(ModelSerializer):
+    class Meta:
+        model = Config
+        fields = (
+            'created',
+            'type',
+            'name',
+            'version',
+            'is_current',
+            'description',
+            'user',
+            'content',
+        )
+
+    def new_version(self):
+        config = Config.get_latest_version(self.initial_data['type'], self.initial_data['name'])
+        if config:
+            return config.version + 1
+        return 0
+
+    def update_data(self):
+        '''
+        Update initial data with created time, version and user ID.
+        '''
+        request = self.context['request']
+        access_token = request.COOKIES.get('access_token')
+
+        self.initial_data['created'] = prepare_date(datetime.now())
+        self.initial_data['version'] = self.new_version()
+        self.initial_data['user'] = get_user_by_access_token(access_token).id
+
+    def get_data(self):
+        '''
+        A universal method for obtaining data that takes into account both the object
+        with which the serializer can be initialized and the data.
+        '''
+        if hasattr(self, 'initial_data') and self.instance:
+            data = self.to_representation(self.instance)
+            data.update(self.initial_data)
+            return data
+        if hasattr(self, 'initial_data'):
+            return self.initial_data
+        if self.instance:
+            return self.to_representation(self.instance)
+        return {}
+
+    def ensure_json(self, config_content):
+        if isinstance(config_content, (dict, list)):
+            return config_content
+        try:
+            return json.loads(config_content)
+        except (json.JSONDecodeError, TypeError) as e:
+            msg = 'Invalid format: JSON is expected'
+            raise serializers.ValidationError(msg) from e
+
+    def get_json_schema(self, config_type, config_name):
+        if config_type == ConfigTypes.REPORT:
+            return load_schema('report')
+        if config_type == ConfigTypes.GLOBAL and config_name == GlobalConfigNames.PER_CONF:
+            return load_schema('per_conf')
+        return None
+
+    def validate_name(self, name):
+        possible_global_config_names = GlobalConfigNames.all()
+        if (
+            self.initial_data['type'] == ConfigTypes.GLOBAL
+            and name not in possible_global_config_names
+        ):
+            msg = (
+                f'Unsupported global config name. Possible are: {possible_global_config_names}'
+            )
+            raise serializers.ValidationError(msg)
+        return name
+
+    def validate_content(self, content):
+        '''
+        Do the preprocessing and validate config content using the appropriate JSON schema.
+        '''
+        content = self.ensure_json(content)
+        data = self.get_data()
+        json_schema = self.get_json_schema(data['type'], data['name'])
+        if json_schema:
+            try:
+                validate(instance=content, schema=json_schema)
+            except jsonschema.exceptions.ValidationError as jeve:
+                jeve_msg = jeve.message[0].lower() + jeve.message[1:]
+                msg = f'Invalid format: {jeve_msg}'
+                raise serializers.ValidationError(msg) from jeve
+        return content
+
+    def get_or_create(self, validated_data):
+        config = get_or_none(
+            Config.objects,
+            content=validated_data['content'],
+        )
+        if config:
+            return config, False
+        config = self.create(validated_data)
+        return config, True
+
+    def create(self, validated_data):
+        config_type = validated_data['type']
+        config_name = validated_data['name']
+        current = Config.get_current_version(config_type, config_name)
+        if current:
+            current.is_current = False
+            current.save()
+        return Config.objects.create(**validated_data)

--- a/bublik/interfaces/api_v2/__init__.py
+++ b/bublik/interfaces/api_v2/__init__.py
@@ -12,6 +12,7 @@ from .auth import (
     RefreshTokenView,
     RegisterView,
 )
+from .config import ConfigViewSet
 from .dashboard import (
     DashboardFormatting,
     DashboardPayload,
@@ -63,4 +64,5 @@ __all__ = [
     'clear_all_runs_stats_cache',
     'ReportViewSet',
     'URLShortnerView',
+    'ConfigViewSet',
 ]

--- a/bublik/interfaces/api_v2/config.py
+++ b/bublik/interfaces/api_v2/config.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
+
+import logging
+import re
+
+import per_conf
+
+from rest_framework import status
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.viewsets import ModelViewSet
+
+from bublik.core.auth import auth_required
+from bublik.core.config.filters import ConfigFilter
+from bublik.core.queries import get_or_none
+from bublik.data.models import Config
+from bublik.data.serializers import ConfigSerializer
+
+
+logger = logging.getLogger('')
+
+
+class ConfigViewSet(ModelViewSet):
+    queryset = Config.objects.all()
+    serializer_class = ConfigSerializer
+
+    def filter_queryset(self, queryset):
+        return ConfigFilter(queryset=self.queryset).qs
+
+    def get_or_create(self, data):
+        serializer = self.get_serializer(data=data)
+        serializer.update_data()
+        serializer.is_valid(raise_exception=True)
+        return serializer.get_or_create(serializer.validated_data)
+
+    @auth_required(as_admin=True)
+    @action(detail=False, methods=['get'])
+    def create_by_per_conf(self, request, *args, **kwargs):
+        '''
+        Create global config object by per_conf.py (if it does not exist).
+        Return a created object or an existing per_conf global config object.
+        Request: GET api/v2/config/create_by_per_conf.
+        '''
+        global_config = get_or_none(
+            Config.objects,
+            type='global',
+            name='per_conf',
+        )
+        if global_config:
+            return Response(
+                self.get_serializer(global_config).data,
+                status=status.HTTP_302_FOUND,
+            )
+
+        # convert per_conf.py into dict
+        per_conf_dict = {}
+        args = dir(per_conf)
+        args = [arg for arg in args if not re.fullmatch(r'__.+?__', arg)]
+        per_conf_dict = {arg: getattr(per_conf, arg, None) for arg in args}
+
+        # convert tuple into list
+        if 'RUN_STATUS_BY_NOK_BORDERS' in per_conf_dict:
+            per_conf_dict['RUN_STATUS_BY_NOK_BORDERS'] = list(
+                per_conf_dict['RUN_STATUS_BY_NOK_BORDERS'],
+            )
+
+        data = {
+            'type': 'global',
+            'name': 'per_conf',
+            'description': 'The main project config',
+            'content': per_conf_dict,
+        }
+        config, created = self.get_or_create(data)
+        config_data = self.get_serializer(config).data
+        if not created:
+            return Response(config_data, status=status.HTTP_302_FOUND)
+        return Response(config_data, status=status.HTTP_201_CREATED)
+
+    @auth_required(as_admin=True)
+    def create(self, request, *args, **kwargs):
+        '''
+        Create config with passed type, name, description and content
+        (if object with the same content does not exist).
+        Return a created object or an existing object with the passed content.
+        Request: POST api/v2/config.
+        '''
+        data = {
+            k: v
+            for k, v in request.data.items()
+            if k in ['type', 'name', 'description', 'content']
+        }
+        config, created = self.get_or_create(data)
+        config_data = self.get_serializer(config).data
+        if not created:
+            return Response(config_data, status=status.HTTP_302_FOUND)
+        return Response(config_data, status=status.HTTP_201_CREATED)
+
+    @auth_required(as_admin=True)
+    def partial_update(self, request, *args, **kwargs):
+        '''
+        Update or create new version of the config by changing its description or content.
+        Request: PATCH api/v2/config/<ID>.
+        '''
+        config = self.get_object()
+
+        # prepare data for updating/creating a new version
+        config_data = self.get_serializer(config).data
+        updated_data = {'type': config_data['type'], 'name': config_data['name']}
+        for attr in ['description', 'content']:
+            updated_data[attr] = (
+                request.data[attr] if attr in request.data else config_data[attr]
+            )
+
+        if 'content' in request.data:
+            # create new object version
+            new_config, created = self.get_or_create(updated_data)
+            new_config_data = self.get_serializer(new_config).data
+            if not created:
+                return Response(new_config_data, status=status.HTTP_302_FOUND)
+            return Response(new_config_data, status=status.HTTP_201_CREATED)
+
+        if 'description' in request.data:
+            # update object with passed description
+            serializer = self.get_serializer(config, data=updated_data, partial=True)
+            serializer.is_valid(raise_exception=True)
+            self.perform_update(serializer)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+
+        return Response(config_data, status=status.HTTP_200_OK)
+
+    @auth_required(as_admin=True)
+    def destroy(self, request, *args, **kwargs):
+        return super().destroy(request, *args, **kwargs)
+
+    @auth_required(as_admin=True)
+    @action(detail=True, methods=['get'])
+    def all_versions(self, request, *args, **kwargs):
+        '''
+        Get all versions of passed config.
+        Request: GET api/v2/config/<ID>/all_versions.
+        '''
+        config = self.get_object()
+        config_data = self.get_serializer(config).data
+
+        all_config_versions = Config.objects.filter(
+            type=config_data['type'],
+            name=config_data['name'],
+        ).values('id', 'is_current', 'description', 'created')
+
+        data = {
+            'type': config_data['type'],
+            'name': config_data['name'],
+            'all_config_versions': all_config_versions,
+        }
+        return Response(data, status=status.HTTP_200_OK)
+
+    @auth_required(as_admin=True)
+    @action(detail=True, methods=['get'])
+    def mark_as_current(self, request, *args, **kwargs):
+        '''
+        Make passed config version current.
+        Request: GET api/v2/config/<ID>/mark_as_current.
+        '''
+        config = self.get_object()
+        config_data = self.get_serializer(config).data
+
+        current = Config.get_current_version(config_data['type'], config_data['name'])
+        current.is_current = False
+        current.save()
+
+        config.is_current = True
+        config.save()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @auth_required(as_admin=True)
+    def list(self, request):
+        current_configs = Config.objects.filter(is_current=True).values(
+            'id',
+            'type',
+            'name',
+            'description',
+            'created',
+        )
+        return Response(current_configs, status=status.HTTP_200_OK)
+
+    @auth_required(as_admin=True)
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request)

--- a/bublik/interfaces/api_v2/performance.py
+++ b/bublik/interfaces/api_v2/performance.py
@@ -6,12 +6,11 @@ import logging
 from urllib.parse import urlencode
 
 from django.conf import settings
-import per_conf
-
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from bublik.core.config.services import getattr_from_per_conf
 from bublik.core.shortcuts import build_absolute_uri
 
 
@@ -46,7 +45,10 @@ class PerformanceCheckView(APIView):
         hist_args_common = urlencode(hist_args_common)
 
         try:
-            hist_args_per_conf = per_conf.HISTORY_SEARCH_EXAMPLE
+            hist_args_per_conf = getattr_from_per_conf(
+                'HISTORY_SEARCH_EXAMPLE',
+                required=True,
+            )
             hist_args_intense = urlencode(hist_args_per_conf) + f'&{hist_args_common}'
 
             hist_args_base = {

--- a/bublik/interfaces/api_v2/server.py
+++ b/bublik/interfaces/api_v2/server.py
@@ -2,13 +2,13 @@
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
 from django.conf import settings
-import per_conf
 
 from rest_framework.decorators import action
 from rest_framework.mixins import RetrieveModelMixin
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
+from bublik.core.config.services import getattr_from_per_conf
 
 __all__ = [
     'ServerViewSet',
@@ -21,7 +21,7 @@ class ServerViewSet(RetrieveModelMixin, GenericViewSet):
     @action(detail=False, methods=['get'])
     def project(self, request):
         # TODO: The existence of PROJECT in per_conf should be checked when the server starts
-        return Response({'project': per_conf.PROJECT})
+        return Response({'project': getattr_from_per_conf('PROJECT', required=True)})
 
     @action(detail=False, methods=['get'])
     def version(self, request):

--- a/bublik/urls.py
+++ b/bublik/urls.py
@@ -32,6 +32,7 @@ api_v2_router.register(r'importruns', api_v2.ImportrunsViewSet, 'importruns')
 api_v2_router.register(r'auth/profile', api_v2.ProfileViewSet, 'profile')
 api_v2_router.register(r'auth/admin', api_v2.AdminViewSet, 'admin')
 api_v2_router.register(r'report', api_v2.ReportViewSet, 'report')
+api_v2_router.register(r'config', api_v2.ConfigViewSet, 'config')
 
 ### URL patterns mounting ###
 urlpatterns = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,7 @@ idna==2.8
 importlab==0.8.1
 importlib-metadata==4.13.0
 isort==5.8.0
+jsonschema==4.17.3
 kombu==5.3.3
 logilab-astng==0.24.3
 logilab-common==1.4.2

--- a/templates/settings.py.template
+++ b/templates/settings.py.template
@@ -392,33 +392,3 @@ VIEWS_TIMEOUTS = {
     'history_list_base': 120,
     'history_list_intense': 120,
 }
-
-REPORT_CONFIG_COMPONENTS = {
-    'required_keys': [
-        'id',
-        'name',
-        'description',
-        'version',
-        'title_content',
-        'test_names_order',
-        'tests',
-    ],
-    'required_test_keys': [
-        'table_view',
-        'chart_view',
-        'axis_x',
-        'axis_y',
-        'sequence_group_arg',
-        'percentage_base_value',
-        'sequence_name_conversion',
-        'not_show_args',
-        'records_order',
-    ],
-    'possible_axis_y_keys': [
-        'tool',
-        'type',
-        'name',
-        'keys',
-        'aggr',
-    ],
-}


### PR DESCRIPTION
# Info

1. `Config` model, the corresponding serializer `ConfigSerializer` and `ConfigViewSet` have been created. This makes it possible to store configurations in the database, as well as manage them (CRUD).
2. The source of `per_conf` attributes and report configurations getting has been changed. Now this data is obtained from the corresponding database configuration objects.

# Overview of changes
## Models
`Config` model contains  configuration information.
Fields:
- `created` (timestamp of the config creation);
- `type` (configuration type. All available types are contained in the `ConfigTypes` class);
- `name` (configuration name. The namespace for global configurations is limited. All available global configuration names are contained in the `GlobalConfigNames` class);
- `version` (configuration version);
- `is_current` (validity flag. For each type-name pair, only one configuration can have `is_current=True`);
- `description` (configuration description. May be blank);
- `user` (creator of the object);
- `content` (configuration content in JSON format).

Methods:
- `get_latest_version()` class method is used to get the latest version of the configuration with the passed type and name;
- `get_current_version()` class method is used to get current version of the configuration with the passed type and name;
- `delete()` method. Redefined so that if a current version is deleted, the latest version is marked as current.

## Serializers
`ConfigSerializer` — `Config` model serializer.
Methods:
- `new_version()` method is used to get the version value for a new object;
- `update_data()` method is used to update initial data with created time, version and user ID;
- `get_data()` method is used to get data from an object and/or data with which the serializer was initialized;
- `ensure_json()` method is used to convert content to JSON;
- `get_json_schema()` method is used to update_data() method is used to update initial data with created time, version and user ID;
- `validate_name()` method used to validate the value passed as the name for the global configuration;
- `validate_content()` method is used to validate content using the appropriate JSON schema;
- `get_or_create()` method is used to get an object by content or create a new one;
- `create()` method. Redefined so that the new object becomes the only one current for its type-name.

## API. Configurations
`ConfigViewSet` have been created.
Here is a list of new endpoints and some description of how to work with them.
> **Note!**
> All methods require administrator permission. The `access_token` is retrieved from request cookies.

### 1. api/v2/config/
Allows you to get a list of current configurations.
Allowed methods: GET
Response data: 
```
[
    {
        "id": 8,
        "type": "report",
        "name": "dpdk-ethdev-ts",
        "description": "Performance report config for dpdk-ethdev-ts",
        "created": "2024-08-13T14:29:30.598176Z"
    },
    {
        "id": 1,
        "type": "global",
        "name": "per_conf",
        "description": "The main project config",
        "created": "2024-08-12T15:35:08.555075Z"
    }
]
```
Response status code: 200

### 2. api/v2/config/\<ID\>
Allows you to CRUD configurations.
Allowed methods: GET, POST, PATCH, DELETE
#### GET
Allows you to get configuration data.
Response data: 
```
{
    "created": "2024-08-13T14:29:30.598176Z",
    "type": "report",
    "name": "dpdk-ethdev-ts",
    "version": 0,
    "is_current": true,
    "description": "Performance report config for dpdk-ethdev-ts",
    "user": 1,
    "content": {
        "tests": {
            "testpmd_txonly": {
                "axis_x": "testpmd_command_txpkts",
                "axis_y": [
                    {
                        "keys": {
                            "Side": [
                                "Tx"
                            ]
                        },
                        "type": [
                            "throughput"
                        ]
                    },
                    {
                        "aggr": [
                            "mean"
                        ],
                        "keys": {
                            "Side": [
                                "Tx"
                            ]
                        },
                        "type": [
                            "pps"
                        ]
                    }
                ],
                "chart_view": true,
                "table_view": true,
                "not_show_args": {},
                "records_order": [],
                "sequence_group_arg": "testpmd_arg_txq",
                "percentage_base_value": 1,
                "sequence_name_conversion": {}
            }
        },
        "title_content": [
            "CAMPAIGN_DATE",
            "CFG"
        ],
        "test_names_order": [
            "testpmd_txonly"
        ]
    }
}
```
Response status code: 200

#### POST
Allows you to create configuration.
POST request data:
```
{
    "type": <configuration type>,
    "name": <configuration name>,
    "description": <configuration description>,
    "content":  <configuration content>
}
```
Validation info:
- `type`: only `global` and `report` are available (now), required;
- `name`: only `per_conf` is available for `global` (now), required;
- `description`: may be blank;
- `content`: must be in JSON format and conform to the corresponding JSON schema; required. 

Possible cases and responses:
- Provided invalid name for global
Response data: 

```
{
    "type": "ValidationError",
    "message": {
        "name": [
            "Unsupported global config name. Possible are: ['per_conf']"
        ]
    }
}
```
Response status code: 400

- Provided invalid content
Response data: 

```
{
    "type": "ValidationError",
    "message": {
        "content": [
            "Invalid format: 'PROJECT' is a required property"
        ]
    }
}
```
Response status code: 400

- All data provided is valid
Response data:
```
{
    "created": "2024-08-13T15:01:05.413804Z",
    "type": "report",
    "name": "dpdk-ethdev-ts",
    "version": 1,
    "is_current": true,
    "description": "Updated performance report config for dpdk-ethdev-ts",
    "user": 1,
    "content": {
        "title_content": [
            "CAMPAIGN_DATE",
            "CFG"
        ],
        "test_names_order": [
            "testpmd_rxonly"
        ],
        "tests": {
            "testpmd_rxonly": {
                "table_view": true,
                "chart_view": true,
                "axis_x": "packet_size",
                "axis_y": [
                    {
                        "type": [
                            "throughput"
                        ],
                        "keys": {
                            "Side": [
                                "Rx"
                            ]
                        }
                    },
                    {
                        "type": [
                            "pps"
                        ],
                        "keys": {
                            "Side": [
                                "Rx"
                            ]
                        },
                        "aggr": [
                            "mean"
                        ]
                    }
                ],
                "sequence_group_arg": "testpmd_arg_rxq",
                "percentage_base_value": 1,
                "sequence_name_conversion": {},
                "not_show_args": {},
                "records_order": []
            }
        }
    }
}
```
Response status code: 
- 201 (if created)
- 302 (if configuration with the same content already exist)

#### PATCH
Allows you to update configuration.
PATCH request data:
```
{
    "description": <configuration description>,
    "content":  <configuration content>
}
```
Validation info:
- `description`: may be blank;
- `content`: must be in JSON format and conform to the corresponding JSON schema; may be blank. 

Possible cases and responses:
- Invalid data was provided (see POST cases)
- All data provided is valid
PATCH request data:
```
{
    "description": "Updated description for dpdk-ethdev-ts report config",
    "content": {
        "title_content": [
            "CAMPAIGN_DATE",
            "CFG"
        ],
        "test_names_order": [
            "testpmd_rxonly"
        ],
        "tests": {
            "testpmd_rxonly": {
                "table_view": false,
                "chart_view": true,
                "axis_x": "packet_size",
                "axis_y": [
                    {
                        "type": [
                            "throughput"
                        ],
                        "keys": {
                            "Side": [
                                "Rx"
                            ]
                        }
                    },
                    {
                        "type": [
                            "pps"
                        ],
                        "keys": {
                            "Side": [
                                "Rx"
                            ]
                        },
                        "aggr": [
                            "mean"
                        ]
                    }
                ],
                "sequence_group_arg": "testpmd_arg_rxq",
                "percentage_base_value": 1,
                "sequence_name_conversion": {},
                "not_show_args": {},
                "records_order": []
            }
        }
    }
}
```
Response data: 
```
{
    "created": "2024-08-14T08:25:37.237821Z",
    "type": "report",
    "name": "dpdk-ethdev-ts-rxonly",
    "version": 0,
    "is_current": true,
    "description": "Updated description for dpdk-ethdev-ts report config",
    "user": 1,
    "content": {
        "title_content": [
            "CAMPAIGN_DATE",
            "CFG"
        ],
        "test_names_order": [
            "testpmd_rxonly"
        ],
        "tests": {
            "testpmd_rxonly": {
                "table_view": false,
                "chart_view": true,
                "axis_x": "packet_size",
                "axis_y": [
                    {
                        "type": [
                            "throughput"
                        ],
                        "keys": {
                            "Side": [
                                "Rx"
                            ]
                        }
                    },
                    {
                        "type": [
                            "pps"
                        ],
                        "keys": {
                            "Side": [
                                "Rx"
                            ]
                        },
                        "aggr": [
                            "mean"
                        ]
                    }
                ],
                "sequence_group_arg": "testpmd_arg_rxq",
                "percentage_base_value": 1,
                "sequence_name_conversion": {},
                "not_show_args": {},
                "records_order": []
            }
        }
    }
}
```
Response status code: 
- 200 (if content was not provided)
- 201 (if new content was provided)
- 302 (if object with passed content already exist)

#### DELETE
Allows you to delete configuration.
Response status code: 204

### 3. api/v2/config/\<ID\>/mark_as_current
Allows you to mark the configuration version as current.
Allowed methods: GET
Response status code: 204

### 4. api/v2/config/\<ID\>/all_versions
Allows you to get all versions of the passed configuration.
Allowed methods: GET
Response data:
```
{
    "type": "report",
    "name": "dpdk-ethdev-ts",
    "all_config_versions": [
        {
            "id": 25,
            "is_current": false,
            "description": "Report config for dpdk-ethdev-ts",
            "created": "2024-08-14T13:34:15.862297Z"
        },
        {
            "id": 26,
            "is_current": true,
            "description": "Updated report config for dpdk-ethdev-ts",
            "created": "2024-08-14T13:34:38.636108Z"
        }
    ]
}
```
Response status code: 200

### 5. api/v2/config/create_by_per_conf
Allows you to automatically create a global configuration based on the existing per_conf.py.
Allowed methods: GET
Response data:
```
{
    "created": "2024-08-14T10:02:25.797643Z",
    "type": "global",
    "name": "per_conf",
    "version": 0,
    "is_current": true,
    "description": "The main project config",
    "user": 1,
    "content": {
        "CSRF_TRUSTED_ORIGINS": [
            "https://<host_name>/"
        ],
        "DASHBOARD_HEADER": {
            "ts_name": "Test Suite",
            "configuration": "Configuration",
            "status": "Status",
            "total": "Total",
            "unexpected": "NOK",
            "progress": "Executed",
            "notes": "Notes"
        },
        "DASHBOARD_PAYLOAD": {
            "configuration": "go_run",
            "total": "go_tree",
            "unexpected": "go_run_failed",
            "notes": "go_bug"
        },
        "DASHBOARD_RUNS_SORT": [
            "start"
        ],
        "EMAIL_PROJECT_WATCHERS": [],
        "FILES_TO_GENERATE_METADATA": [
            "metadata.txt"
        ],
        "PROJECT": "project-name",
        "RUN_COMPLETE_FILE": ".finished",
        "RUN_KEY_METAS": [
            "START_TIMESTAMP"
        ],
        "RUN_STATUS_BY_NOK_BORDERS": [
            20.0,
            80.0
        ],
        "RUN_STATUS_META": "run_status",
        "SPECIAL_CATEGORIES": [
            "Test Suite",
            "Configuration"
        ]
    }
}
```
Response status code: 
- 201 (if created)
- 302 (if configuration with the same content already exist)

## API. Reports
Now the source of configurations for reports is a database.

**The format of the list of available configurations has been changed!**
Example:
Request: GET /bublik/api/v2/report/\<RUN_ID\>/configs/
Response data: 
```
{
    "run_report_configs": [
        {
            "id": 26,
            "created": "2024-08-14T13:34:38.636108Z",
            "name": "dpdk-ethdev-ts",
            "version": 1,
            "description": "Updated report config for dpdk-ethdev-ts"
        },
        {
            "id": 27,
            "created": "2024-08-14T14:03:00.927002Z",
            "name": "dpdk-ethdev-ts-txonly",
            "version": 0,
            "description": "TXonly report config for dpdk-ethdev-ts"
        }
    ]
}
```
Response status code: 200
> **Note!**
> The key `invalid_report_config_files ` is no longer supported.

## Other
Now the main source of `per_conf` attributes is the database. If there is no corresponding object in the database, the `per_conf` attributes are obtained from the `per_conf.py` (as it was before) and the warning is logged.