### PR TITLE
Run stats: add objectives support

### DIFF
--- a/bublik/core/importruns/source/execution.py
+++ b/bublik/core/importruns/source/execution.py
@@ -15,6 +15,7 @@ from bublik.core.run.objects import (
     add_expected_result,
     add_iteration,
     add_iteration_result,
+    add_objective,
     add_obtained_result,
     add_tags,
     add_test,
@@ -63,6 +64,11 @@ def handle_iteration(
         parent_package,
         data['tin'],
         data['test_id'],
+    )
+
+    add_objective(
+        iteration_result,
+        data['objective'],
     )
 
     plan_id = int(data['plan_id'])

--- a/bublik/core/run/objects.py
+++ b/bublik/core/run/objects.py
@@ -274,6 +274,13 @@ def set_run_status(run, status_key):
         logger.error('cannot set run status because RUN_STATUS_META is not set')
 
 
+def add_objective(iteration_result, objective):
+    add_meta_result(
+        m_data={'type': 'objective', 'value': objective},
+        mr_data={'result': iteration_result},
+    )
+
+
 def add_obtained_result(iteration_result, result, verdicts=None, err=None):
     if verdicts is not None:
         for serial, verdict in enumerate(verdicts):

--- a/bublik/data/models/meta.py
+++ b/bublik/data/models/meta.py
@@ -28,7 +28,7 @@ class Meta(models.Model):
         max_length=64,
         help_text='''\
 The meta type, enumeration: result, verdict, note, error, tag, label, \
-revision, branch, repo, log, import, count.''',
+revision, branch, repo, log, import, count, objective.''',
         db_index=True,
     )
     value = models.TextField(null=True, blank=True, help_text='The meta value or none.')

--- a/scripts/xml_log_parser
+++ b/scripts/xml_log_parser
@@ -74,6 +74,7 @@ sub handle_start
         $cur_iter->{result} = "";
         $cur_iter->{err} = "";
         $cur_iter->{result_expected} = "";
+        $cur_iter->{objective} = "";
         $cur_iter->{verdicts} = [];
         $cur_iter->{verdicts_expected} = [];
         $cur_iter->{artifacts} = [];
@@ -164,6 +165,10 @@ sub handle_char
     elsif ($p->current_element() eq "end-ts")
     {
         $p->{end_ts} .= $str;
+    }
+    elsif ($p->current_element() eq "objective")
+    {
+        $p->{objective} = $str;
     }
     elsif ($p->current_element() eq "verdict")
     {
@@ -274,6 +279,10 @@ sub handle_end
     {
         $cur_iter->{end_ts} = fix_date($p->{end_ts});
         $last_ts = $cur_iter->{end_ts};
+    }
+    elsif ($e eq "objective")
+    {
+        $cur_iter->{objective} = $p->{objective};
     }
     elsif ($e eq "verdict")
     {


### PR DESCRIPTION
1. Store objectives in the database during import.
2. Add objectives to detailed run statistics.