### PR TITLE
Report: cleanup, bugfix and improve usability

### DIFF
--- a/bublik/core/report/components.py
+++ b/bublik/core/report/components.py
@@ -89,7 +89,7 @@ class ReportMeasurementLevel:
         self.type = 'measurement-block'
         self.warnings = []
         self.sequence_group_arg = test_config['sequence_group_arg']
-        self.axis_x_key = test_config['axis_x']
+        self.axis_x_key = f'{test_config['axis_x']} / {test_config['sequence_group_arg']}'
         self.axis_x_label = test_config['axis_x']
         self.axis_y_label = record_info
         self.id = '_'.join([av_lvl_id, self.axis_y_label.replace(' ', '')])

--- a/bublik/core/report/services.py
+++ b/bublik/core/report/services.py
@@ -254,7 +254,10 @@ def filter_by_axis_y(mmrs_test, axis_y):
                 measurement__metas__value__in=ms_values,
             )
         mmrs_test_axis_y = mmrs_test_axis_y.union(mmrs_test_measurement)
-    return mmrs_test_axis_y
+
+    # the union will be impossible to filter out
+    mmrs_test_axis_y_ids = mmrs_test_axis_y.values_list('id', flat=True)
+    return mmrs_test.filter(id__in=mmrs_test_axis_y_ids)
 
 
 def filter_by_not_show_args(mmrs_test, not_show_args):

--- a/bublik/core/report/services.py
+++ b/bublik/core/report/services.py
@@ -221,12 +221,13 @@ def filter_by_axis_y(mmrs_test, axis_y):
     '''
     Filter passed measurement results QS by axis y value from config.
     '''
-    axis_y_mmrs = MeasurementResult.objects.none()
+    mmrs_test_axis_y = MeasurementResult.objects.none()
     for measurement in axis_y:
+        mmrs_test_measurement = mmrs_test.all()
         # filter by tool
         if 'tool' in measurement:
             tools = measurement.pop('tool')
-            mmrs_test = mmrs_test.filter(
+            mmrs_test_measurement = mmrs_test.filter(
                 measurement__metas__name='tool',
                 measurement__metas__type='tool',
                 measurement__metas__value__in=tools,
@@ -237,23 +238,23 @@ def filter_by_axis_y(mmrs_test, axis_y):
             meas_key_mmrs = MeasurementResult.objects.none()
             keys_vals = measurement.pop('keys')
             for key_name, key_vals in keys_vals.items():
-                meas_key_mmrs_group = mmrs_test.filter(
+                meas_key_mmrs_group = mmrs_test_measurement.filter(
                     measurement__metas__name=key_name,
                     measurement__metas__type='measurement_key',
                     measurement__metas__value__in=key_vals,
                 )
                 meas_key_mmrs = meas_key_mmrs.union(meas_key_mmrs_group)
-            mmrs_test = meas_key_mmrs
+            mmrs_test_measurement = meas_key_mmrs
 
         # filter by measurement subjects (type, name, aggr)
         for ms, ms_values in measurement.items():
-            mmrs_test = mmrs_test.filter(
+            mmrs_test_measurement = mmrs_test_measurement.filter(
                 measurement__metas__name=ms,
                 measurement__metas__type='measurement_subject',
                 measurement__metas__value__in=ms_values,
             )
-        axis_y_mmrs = axis_y_mmrs.union(mmrs_test)
-    return axis_y_mmrs
+        mmrs_test_axis_y = mmrs_test_axis_y.union(mmrs_test_measurement)
+    return mmrs_test_axis_y
 
 
 def filter_by_not_show_args(mmrs_test, not_show_args):

--- a/bublik/core/report/services.py
+++ b/bublik/core/report/services.py
@@ -43,8 +43,10 @@ def check_report_config(report_config):
     try:
         report_config_components = settings.REPORT_CONFIG_COMPONENTS
     except AttributeError as ae:
-        msg = ("The key 'REPORT_CONFIG_COMPONENTS' is missing in the settings. "
-               "Take the 'django_settings' deployment step.")
+        msg = (
+            "The key 'REPORT_CONFIG_COMPONENTS' is missing in the settings. "
+            "Take the 'django_settings' deployment step."
+        )
         raise AttributeError(
             msg,
         ) from ae

--- a/bublik/core/report/services.py
+++ b/bublik/core/report/services.py
@@ -189,7 +189,11 @@ def args_type_convesion(point_groups_by_test_name):
 
 def args_sort(records_order, args_vals):
     if records_order:
-        return {arg: args_vals[arg] for arg in records_order if arg in args_vals}
+        args_vals_sorted = {arg: args_vals[arg] for arg in records_order if arg in args_vals}
+        args_vals_other = {
+            arg: val for arg, val in args_vals.items() if arg not in args_vals_sorted
+        }
+        return args_vals_sorted | args_vals_other
     return dict(sorted(args_vals.items()))
 
 

--- a/bublik/core/report/services.py
+++ b/bublik/core/report/services.py
@@ -103,6 +103,8 @@ def build_axis_y_name(mmr):
     # get metas
     meta_subjects = {}
     meta_keys = {}
+    for meta in mmr.measurement.metas.filter(type='tool'):
+        meta_subjects[meta.name] = meta.value
     for meta in mmr.measurement.metas.filter(
         type='measurement_subject',
         name__in=['name', 'type', 'aggr', 'base_units', 'multiplier'],

--- a/bublik/interfaces/api_v2/report.py
+++ b/bublik/interfaces/api_v2/report.py
@@ -208,7 +208,7 @@ class ReportViewSet(RetrieveModelMixin, GenericViewSet):
                 [
                     'sequence_group_arg_val',
                     'sequence_group_arg',
-                    point['sequence_group_arg_val'],
+                    point['sequence_group_arg_val'][1],
                 ],
             ]
             for match in matches_list:

--- a/bublik/interfaces/api_v2/report.py
+++ b/bublik/interfaces/api_v2/report.py
@@ -97,10 +97,10 @@ class ReportViewSet(RetrieveModelMixin, GenericViewSet):
         # check if the config ID has been passed
         report_config_id = request.query_params.get('config')
         if not report_config_id:
-            msg = 'report config wasn\'t passed'
+            msg = 'Report config wasn\'t passed'
             return Response(
                 status=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                data={'message': msg},
+                data={'type': 'ValueError', 'message': msg},
             )
 
         # check if there is a config of the correct format with the passed config ID

--- a/bublik/interfaces/api_v2/report.py
+++ b/bublik/interfaces/api_v2/report.py
@@ -200,6 +200,7 @@ class ReportViewSet(RetrieveModelMixin, GenericViewSet):
 
         def not_processed_point_conversion(point):
             point = point.__dict__
+            point['common_args'] = common_args[point['test_name']]
             point.pop('axis_y')
             point['reasons'] = []
             axis_x_val = list(point['point'].keys())[0] if list(point['point'].keys()) else None


### PR DESCRIPTION
1. Cleanup.
2. Fix filtering by measurements and display of sequence group argument of not processed points.
3. Make displayed error messages, y-axis label, table header, not processed points data and report structure more informative.
4. Make report config more flexible (add the possibility of partial filtering by test name).