### PR TITLE
Add test comments management

### DIFF
--- a/bublik/core/auth.py
+++ b/bublik/core/auth.py
@@ -3,6 +3,8 @@
 
 from functools import wraps
 
+import per_conf
+
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -72,3 +74,25 @@ def auth_required(as_admin=False):
             return function(*args, **kwargs)
         return wrapper
     return decorator
+
+
+def check_action_permission(action):
+    '''
+    Check if the action requires permission.
+    '''
+
+    def wrapper(func):
+        @wraps(func)
+        def inner(*args, **kwargs):
+            not_permission_required_actions = getattr(
+                per_conf,
+                'NOT_PERMISSION_REQUIRED_ACTIONS',
+                [],
+            )
+            if action in not_permission_required_actions:
+                return func(*args, **kwargs)
+            return auth_required(as_admin=True)(func)(*args, **kwargs)
+
+        return inner
+
+    return wrapper

--- a/bublik/data/models/__init__.py
+++ b/bublik/data/models/__init__.py
@@ -39,6 +39,7 @@ from .meta import (
 from .reference import Reference
 from .result import (
     MetaResult,
+    MetaTest,
     ResultStatus,
     ResultType,
     RunConclusion,
@@ -81,4 +82,5 @@ __all__ = [
     'UserManager',
     'UserRoles',
     'EndpointURL',
+    'MetaTest',
 ]

--- a/bublik/data/models/meta.py
+++ b/bublik/data/models/meta.py
@@ -28,7 +28,7 @@ class Meta(models.Model):
         max_length=64,
         help_text='''\
 The meta type, enumeration: result, verdict, note, error, tag, label, \
-revision, branch, repo, log, import, count, objective.''',
+revision, branch, repo, log, import, count, objective, comment.''',
         db_index=True,
     )
     value = models.TextField(null=True, blank=True, help_text='The meta value or none.')

--- a/bublik/data/models/result.py
+++ b/bublik/data/models/result.py
@@ -26,6 +26,7 @@ __all__ = [
     'TestIterationRelation',
     'TestIterationResult',
     'MetaResult',
+    'MetaTest',
 ]
 
 
@@ -555,3 +556,41 @@ Serial number of a meta result, can be used to determine verdicts order.''',
             repr(self.serial),
             repr(self.result),
         )
+
+
+class MetaTest(models.Model):
+    '''
+    The table connects a test with metadata.
+    '''
+
+    updated = models.DateTimeField(help_text='Timestamp of the connection creation.')
+    meta = models.ForeignKey(
+        Meta,
+        on_delete=models.CASCADE,
+        help_text='A metadata identifier.',
+    )
+    serial = models.IntegerField(
+        default=0,
+        help_text='The serial number is used to determine the order of comments.',
+    )
+    test = models.ForeignKey(
+        Test,
+        on_delete=models.CASCADE,
+        help_text='The test identifier.',
+    )
+
+    class Admin:
+        pass
+
+    class Meta:
+        db_table = 'bublik_metatest'
+
+    def delete(self, *args, **kwargs):
+        meta_id = self.meta_id
+        super().delete(*args, **kwargs)
+        metatests_with_meta_id = MetaTest.objects.filter(meta_id=meta_id)
+        if not metatests_with_meta_id:
+            Meta.objects.get(id=meta_id).delete()
+
+    def __repr__(self):
+        return f'MetaTest(test={self.test!r}, serial={self.serial!r}, meta={self.meta!r})'

--- a/bublik/data/serializers/__init__.py
+++ b/bublik/data/serializers/__init__.py
@@ -25,6 +25,7 @@ from .meta import MetaSerializer
 from .reference import ReferenceSerializer
 from .result import (
     MetaResultSerializer,
+    MetaTestSerializer,
     TestArgumentSerializer,
     TestIterationRelationSerializer,
     TestIterationResultSerializer,
@@ -56,4 +57,5 @@ __all__ = [
     'PasswordResetSerializer',
     'UpdateUserSerializer',
     'EndpointURLSerializer',
+    'MetaTestSerializer',
 ]

--- a/bublik/interfaces/api_v2/__init__.py
+++ b/bublik/interfaces/api_v2/__init__.py
@@ -12,6 +12,7 @@ from .auth import (
     RefreshTokenView,
     RegisterView,
 )
+from .comments import TestCommentViewSet
 from .dashboard import (
     DashboardFormatting,
     DashboardPayload,
@@ -63,4 +64,5 @@ __all__ = [
     'clear_all_runs_stats_cache',
     'ReportViewSet',
     'URLShortnerView',
+    'TestCommentViewSet',
 ]

--- a/bublik/interfaces/api_v2/comments.py
+++ b/bublik/interfaces/api_v2/comments.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
+
+import json
+
+from rest_framework import status
+from rest_framework.mixins import DestroyModelMixin
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from bublik.core.auth import check_action_permission
+from bublik.data.models import MetaTest
+from bublik.data.serializers import (
+    MetaTestSerializer,
+)
+
+
+class TestCommentViewSet(DestroyModelMixin, GenericViewSet):
+    serializer_class = MetaTestSerializer
+
+    def get_queryset(self):
+        test_id = self.kwargs.get('test_id')
+        if test_id is not None:
+            return MetaTest.objects.filter(meta__type='comment', test_id=test_id)
+        return MetaTest.objects.none()
+
+    def get_object(self):
+        queryset = self.get_queryset()
+        filter_kwargs = {'meta': self.kwargs.get('pk')}
+        return queryset.get(**filter_kwargs)
+
+    @check_action_permission('manage_test_comments')
+    def create(self, request, *args, **kwargs):
+        '''
+        Add a comment to the Test object by creating MetaTest object that relates it
+        with the received or created Meta object of the comment type.
+        Request: POST tests/<test_id>/comments.
+        '''
+        test_id = self.kwargs.get('test_id')
+        comment_value = request.data.get('comment')
+        serializer = self.get_serializer(
+            data={
+                'test': test_id,
+                'meta': {'type': 'comment', 'value': json.dumps(comment_value)},
+            },
+        )
+        serializer.update_data()
+        serializer.is_valid(raise_exception=True)
+        test_comment, created = serializer.get_or_create(serializer.validated_data)
+        test_comment_data = self.get_serializer(test_comment).data
+        if not created:
+            return Response(test_comment_data, status=status.HTTP_302_FOUND)
+        return Response(test_comment_data, status=status.HTTP_201_CREATED)
+
+    @check_action_permission('manage_test_comments')
+    def partial_update(self, request, *args, **kwargs):
+        '''
+        Update a test comment by deleting the MetaTest object relates the Test object
+        with the Meta object with the old value and creating a new MetaTest object relates
+        the Test object with the received or created Meta object with the new value.
+        Request: PATCH tests/<test_id>/comments/<meta_id>.
+        '''
+        # get new MetaTest object data
+        metatest = self.get_object()
+        upd_comment_value = request.data.get('comment')
+        upd_test_comment_data = self.get_serializer(metatest).data
+        upd_test_comment_data['meta']['value'] = json.dumps(upd_comment_value)
+
+        # validate new MetaTest object data
+        serializer = self.get_serializer(data=upd_test_comment_data)
+        serializer.update_data()
+        serializer.is_valid(raise_exception=True)
+
+        # create a new MetaTest object and delete the old one
+        test_comment, created = serializer.get_or_create(serializer.validated_data)
+        metatest.delete()
+
+        test_comment_data = self.get_serializer(test_comment).data
+        if not created:
+            return Response(test_comment_data, status=status.HTTP_302_FOUND)
+        return Response(test_comment_data, status=status.HTTP_201_CREATED)
+
+    @check_action_permission('manage_test_comments')
+    def destroy(self, request, *args, **kwargs):
+        return super().destroy(request, *args, **kwargs)

--- a/bublik/interfaces/api_v2/results.py
+++ b/bublik/interfaces/api_v2/results.py
@@ -25,7 +25,7 @@ from bublik.core.run.stats import (
     generate_results_details,
     generate_runs_details,
     get_nok_results_distribution,
-    get_run_stats_detailed,
+    get_run_stats_detailed_with_comments,
     get_run_status,
 )
 from bublik.core.run.tests_organization import get_tests_by_name
@@ -125,7 +125,7 @@ class RunViewSet(ModelViewSet):
     @action(detail=True, methods=['get'])
     def stats(self, request, pk=None):
         run = self.get_object()
-        return Response({'results': get_run_stats_detailed(run.id)})
+        return Response({'results': get_run_stats_detailed_with_comments(run.id)})
 
     @action(detail=True, methods=['get'])
     def source(self, request, pk=None):

--- a/bublik/urls.py
+++ b/bublik/urls.py
@@ -32,6 +32,11 @@ api_v2_router.register(r'importruns', api_v2.ImportrunsViewSet, 'importruns')
 api_v2_router.register(r'auth/profile', api_v2.ProfileViewSet, 'profile')
 api_v2_router.register(r'auth/admin', api_v2.AdminViewSet, 'admin')
 api_v2_router.register(r'report', api_v2.ReportViewSet, 'report')
+api_v2_router.register(
+    r'tests/(?P<test_id>[0-9]+)/comments',
+    api_v2.TestCommentViewSet,
+    basename='tests_comments',
+)
 
 ### URL patterns mounting ###
 urlpatterns = [


### PR DESCRIPTION
# Info

1. `MetaTest` model, the corresponding serializer `MetaTestSerializer` and `TestCommentViewSet` have been created. This makes it possible to create, read, update and delete test comments.
2. The `check_action_permission()` function has been created. It allows you to grant access to some actions, by default available only to administrators, to all users.
3. The `get_run_stats_detailed_with_comments()` function has been created. It allows you to get detailed run statistics with comments on the tests.

# Overview of changes
## Models
`MetaTest` model contains information about the relationships between `Test` and `Meta` objects.

Fields:
- `updated` (timestamp of the object creation);
- `test`;
- `meta`;
- `serial` (serial number. Used to sort comments).

Methods:
- `delete()` method. Redefined so that after deleting an object, the existence of relationships between the corresponding `Meta` object and other `Test` objects is checked. If there are no relationships, the `Meta` object is deleted too.

## Serializers
`MetaTestSerializer` — `MetaTest` model serializer.
Methods:
- `update_data()` method is used to set the serial value and timestamp of creation for a new object;
- `validate_meta()` method is used to validate the value passed as the meta value;
- `get_or_create()` method is used to get an object by passed meta and test or create a new one.

## API
`TestCommentViewSet` have been created.
Here is the new endpoint and some description of how to work with it.

### 1. api/v2/tests/<test_id>/comments
Allows you to create test comments.
Allowed methods: POST.

#### POST
Allows you to create test comment.
POST request data:
```
{
    "comment": <comment value>,
}
```
Validation info:
- `comment`: can't be empty, required;

Possible cases and responses:
- Provided empty comment value.
Response data: 

```
{
    "type": "ValidationError",
    "message": {
        "meta": [
            "Empty comments are not supported"
        ]
    }
}
```
Response status code: 400

- All data provided is valid
Response data: 
```
{
    "id": 12,
    "updated": "2024-09-19T15:21:42.259198Z",
    "meta": {
        "name": null,
        "type": "comment",
        "value": "\"New comment\"",
        "comment": null
    },
    "test": 1,
    "serial": 1
}
```
Response status code: 
- 201 (if created)
- 302 (if such a comment to passed test already exists)

### 2. api/v2/tests/<test_id>/comments/<comment_id>
Allows you to update and delete test comments.
Allowed methods: PATCH, DELETE.

#### PATCH
Allows you to update test comment.
PATCH request data:
```
{
    "comment": <updated comment value>
}
```
Validation info: see POST case.
Possible cases and responses: see POST case.

#### DELETE
Allows you to delete test comments.
Response status code: 204

## Auth. Checking permissions
All `TestCommentViewSet` methods require administrator permission by default. To remove this limitation, add `NOT_PERMISSION_REQUIRED_ACTIONS = ['manage_test_comments']` to the project configuration (*per_conf.py*).

## Run statistics
The structure of detailed run statistics has changed. Now, at each of its levels, a list of comments on the corresponding test is available using the "comments" key. Example:
```
...
{
    "result_id": 2,
    "iteration_id": 8003,
    "exec_seqno": 2,
    "parent_id": 8002,
    "type": "test",
    "name": "prologue",
    "period": "1718597810s126-1718597826s992",
    "path": [
        "dpdk-ethdev-ts",
        "prologue"
    ],
    "objective": "",
    "children": [],
    "stats": {
        "passed": 1,
        "failed": 0,
        "passed_unexpected": 0,
        "failed_unexpected": 0,
        "skipped": 0,
        "skipped_unexpected": 0,
        "abnormal": 0
    },
    "comments": [
        {
            "comment_id": "3588",
            "updated": "2024-09-19 15:21:42.259198+00",
            "serial": "0",
            "comment": "First comment"
        },
        {
            "comment_id": "3579",
            "updated": "2024-09-19 14:44:41.155086+00",
            "serial": "1",
            "comment": "Second comment"
        },
        {
            "comment_id": "3598",
            "updated": "2024-09-19 15:49:32.266973+00",
            "serial": "2",
            "comment": "Third comment"
        }
    ]
},
...
```
