### PR TITLE
Report: fix not processed points handling

### DIFF
--- a/bublik/interfaces/api_v2/report.py
+++ b/bublik/interfaces/api_v2/report.py
@@ -209,7 +209,9 @@ class ReportViewSet(RetrieveModelMixin, GenericViewSet):
                 [
                     'sequence_group_arg_val',
                     'sequence_group_arg',
-                    point['sequence_group_arg_val'][1],
+                    point['sequence_group_arg_val'][1]
+                    if point['sequence_group_arg_val']
+                    else None,
                 ],
             ]
             for match in matches_list:


### PR DESCRIPTION
The iteration may not have an argument, corresponding to the sequence group agrument from the report configuration, and, accordingly, it may not have its value.