### PR TITLE
History: fix filtering by expressions

### DIFF
--- a/bublik/core/run/filter_expression.py
+++ b/bublik/core/run/filter_expression.py
@@ -223,7 +223,7 @@ class TestRunMetasGroup:
 
         condition.setParseAction(create_meta)
 
-        prec = pp.operatorPrecedence(
+        prec = pp.infixNotation(
             condition,
             [
                 ('!', 1, pp.opAssoc.RIGHT),


### PR DESCRIPTION
Replace the outdated function, which is not supported in new versions of the pyparsing module, with a supported equivalent.