### PR TITLE
Importruns: fix iteration date parsing

### DIFF
--- a/scripts/xml_log_parser
+++ b/scripts/xml_log_parser
@@ -43,6 +43,7 @@ sub handle_start
     # http://perl-xml.sourceforge.net/faq/#char_events
     $p->{start_ts} = '';
     $p->{end_ts} = '';
+    $p->{duration} = '';
     $p->{verdict} = '';
     $p->{artifact} = '';
     $p->{tags_parsed} = 0;
@@ -137,8 +138,7 @@ sub handle_start
             $p->{plan_parsed} = 1;
         }
 
-        if (defined($attrs{ts_val}) &&
-            $base_tv < 0)
+        if (defined($attrs{ts_val}))
         {
             $base_tv = int($attrs{ts_val});
             $base_date = strftime("%Y.%m.%d", localtime($base_tv));
@@ -165,6 +165,10 @@ sub handle_char
     elsif ($p->current_element() eq "end-ts")
     {
         $p->{end_ts} .= $str;
+    }
+    elsif ($p->current_element() eq "duration")
+    {
+        $p->{duration} .= $str;
     }
     elsif ($p->current_element() eq "objective")
     {
@@ -202,24 +206,53 @@ sub handle_char
     }
 }
 
-sub fix_date
+sub get_unix_date
 {
-    my $date = $_[0];
-    my $date_add = $base_date;
+    my $time = $_[0];
+    my $unix_date = $base_tv;
 
-    if ($date =~ /([0-9]+):([0-9]+):([0-9]+)/)
+    if ($time =~ /([0-9]+):([0-9]+):([0-9]+)/)
     {
-        my $tv = $1 * 60 * 60 + $2 * 60 + $3;
+        my $time_in_sec = $1 * 60 * 60 + $2 * 60 + $3;
         my $day_in_sec = 24 * 60 * 60;
 
-        if ($base_tv % $day_in_sec > $tv)
+        if ($base_tv % $day_in_sec > $time_in_sec)
         {
-            $date_add = strftime("%Y.%m.%d",
-                                 localtime($base_tv + $day_in_sec));
+            $unix_date = $base_tv + $day_in_sec;
         }
     }
 
-    return $date_add." ".$date;
+    return $unix_date;
+}
+
+sub fix_start
+{
+    my $start_time = $_[0];
+    my $unix_start_date = get_unix_date($start_time);
+    my $start_date = strftime("%Y.%m.%d",
+                                 localtime($unix_start_date));
+
+    return $start_date." ".$start_time;
+}
+
+sub fix_end
+{
+    my $start_time = $_[0];
+    my $end_time = $_[1];
+    my $duration = $_[2];
+
+    my $unix_start_date = get_unix_date($start_time);
+    my $unix_end_date = $unix_start_date;
+    if ($duration =~ /([0-9]+):([0-9]+):([0-9]+)/)
+    {
+        my $duration_in_sec = $1 * 60 * 60 + $2 * 60 + $3;
+        $unix_end_date = $unix_start_date + $duration_in_sec;
+    }
+
+    my $end_date = strftime("%Y.%m.%d",
+                                 localtime($unix_end_date));
+
+    return $end_date." ".$end_time;
 }
 
 sub parse_tags
@@ -269,7 +302,7 @@ sub handle_end
 
     if ($e eq "start-ts")
     {
-        $cur_iter->{start_ts} = fix_date($p->{start_ts});
+        $cur_iter->{start_ts} = fix_start($p->{start_ts});
         if ($first_ts eq '')
         {
             $first_ts = $cur_iter->{start_ts};
@@ -277,7 +310,12 @@ sub handle_end
     }
     elsif ($e eq "end-ts")
     {
-        $cur_iter->{end_ts} = fix_date($p->{end_ts});
+        $cur_iter->{end_ts} = $p->{end_ts};
+        $last_ts = $cur_iter->{end_ts};
+    }
+    elsif ($e eq "duration")
+    {
+        $cur_iter->{end_ts} = fix_end($p->{start_ts}, $cur_iter->{end_ts}, $p->{duration});
         $last_ts = $cur_iter->{end_ts};
     }
     elsif ($e eq "objective")


### PR DESCRIPTION
Since testing can take longer than one day, when calculating the start date of an iteration, it is necessary to use the ts_val of the latest message instead of the date of the first one, and also calculate the end date of the iteration using its duration.