### PR TITLE
Report: fix measurement chart label

### DIFF
--- a/bublik/core/measurement/representation.py
+++ b/bublik/core/measurement/representation.py
@@ -130,7 +130,7 @@ class ChartViewBuilder:
             if label_items['sequense_group_arg']
             else None,
             'tool': f': based on {label_items["tool"]}' if label_items['tool'] else None,
-            'keys': f' ({(", ".join(label_items["keys"]))})',
+            'keys': f' ({(", ".join(label_items["keys"]))})' if label_items['keys'] else None,
         }
 
         return ' '.join(


### PR DESCRIPTION
Do not display empty brackets in the measurement chart label if there are no measurement keys.