### PR TITLE
Config: bugfix, refactor and update

### DIFF
--- a/bublik/data/models/config.py
+++ b/bublik/data/models/config.py
@@ -87,6 +87,17 @@ class Config(models.Model):
             is_active=True,
         ).first()
 
+    @classmethod
+    def get_all_versions(cls, config_type, config_name):
+        return (
+            Config.objects.filter(
+                type=config_type,
+                name=config_name,
+            )
+            .order_by('-is_active', '-created')
+            .values('id', 'version', 'is_active', 'description', 'created')
+        )
+
     def delete(self, *args, **kwargs):
         if self.is_active:
             config_type = self.type

--- a/bublik/data/models/config.py
+++ b/bublik/data/models/config.py
@@ -107,15 +107,14 @@ class Config(models.Model):
         self.save()
 
     def delete(self, *args, **kwargs):
-        if self.is_active:
-            config_type = self.type
-            config_name = self.name
-            super().delete(*args, **kwargs)
+        config_type = self.type
+        config_name = self.name
+        config_active = self.is_active
+        super().delete(*args, **kwargs)
+        if config_active:
             latest = self.get_latest_version(config_type, config_name)
             if latest:
                 latest.activate()
-        else:
-            super().delete(*args, **kwargs)
 
     def __repr__(self):
         return (

--- a/bublik/data/models/config.py
+++ b/bublik/data/models/config.py
@@ -98,6 +98,14 @@ class Config(models.Model):
             .values('id', 'version', 'is_active', 'description', 'created')
         )
 
+    def activate(self):
+        active = self.__class__.get_active_version(self.type, self.name)
+        if active:
+            active.is_active = False
+            active.save()
+        self.is_active = True
+        self.save()
+
     def delete(self, *args, **kwargs):
         if self.is_active:
             config_type = self.type
@@ -105,8 +113,7 @@ class Config(models.Model):
             super().delete(*args, **kwargs)
             latest = self.get_latest_version(config_type, config_name)
             if latest:
-                latest.is_active = True
-                latest.save()
+                latest.activate()
         else:
             super().delete(*args, **kwargs)
 

--- a/bublik/interfaces/api_v2/config.py
+++ b/bublik/interfaces/api_v2/config.py
@@ -190,15 +190,7 @@ class ConfigViewSet(ModelViewSet):
         '''
         config = self.get_object()
         config_data = self.get_serializer(config).data
-
-        all_config_versions = (
-            Config.objects.filter(
-                type=config_data['type'],
-                name=config_data['name'],
-            )
-            .order_by('-is_active', '-created')
-            .values('id', 'version', 'is_active', 'description', 'created')
-        )
+        all_config_versions = Config.get_all_versions(config_data['type'], config_data['name'])
 
         data = {
             'type': config_data['type'],

--- a/bublik/interfaces/api_v2/config.py
+++ b/bublik/interfaces/api_v2/config.py
@@ -234,20 +234,13 @@ class ConfigViewSet(ModelViewSet):
         Request: GET api/v2/config/<ID>/change_status.
         '''
         config = self.get_object()
+
         if config.is_active is True:
             config.is_active = False
             config.save()
             return Response(self.get_serializer(config).data, status=status.HTTP_200_OK)
 
-        config_data = self.get_serializer(config).data
-        active = Config.get_active_version(config_data['type'], config_data['name'])
-        if active:
-            active.is_active = False
-            active.save()
-
-        config.is_active = True
-        config.save()
-
+        config.activate()
         return Response(self.get_serializer(config).data, status=status.HTTP_200_OK)
 
     @auth_required(as_admin=True)

--- a/bublik/interfaces/api_v2/config.py
+++ b/bublik/interfaces/api_v2/config.py
@@ -177,7 +177,6 @@ class ConfigViewSet(ModelViewSet):
             return Response(data=json_schema, status=status.HTTP_200_OK)
         msg = 'There is no JSON schema corresponding to the passed configuration type and name'
         return Response(
-            {'message': msg},
             status=status.HTTP_422_UNPROCESSABLE_ENTITY,
             data={'type': 'ValueError', 'message': msg},
         )

--- a/bublik/interfaces/api_v2/report.py
+++ b/bublik/interfaces/api_v2/report.py
@@ -90,7 +90,6 @@ class ReportViewSet(RetrieveModelMixin, GenericViewSet):
         if not report_config_id:
             msg = 'Report config wasn\'t passed'
             return Response(
-                {'message': msg},
                 status=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 data={'type': 'ValueError', 'message': msg},
             )


### PR DESCRIPTION
## API. Config

Note the changes in the behavior of some endpoints:

### 1. api/v2/config/<ID>/change_status
This endpoint is no longer supported. Use `PATCH api/v2/config/<ID> Body: {'is_active': <updated status value>}` instead to update the status.

### 2. api/v2/config/<ID>
Now the PATCH method allows you to update the name and status as well.

Let's consider the case of a conflict between a passed and an already existing name.
Request data: 
```
{
    "name": "DPDK Performance"
}
```
Responce data:
```
{
    "type": "ValueError",
    "message": "A report configuration with the same name already exist",
    "new_config_data": {
        "type": "report",
        "name": "DPDK Performance",
        "description": "Full performance report",
        "content": {
        "title_content": [
            "CAMPAIGN_DATE",
            "CFG"
        ],
        "test_names_order": [
            "testpmd_rxonly"
        ],
        "tests": {
            "testpmd_rxonly": {
                "table_view": true,
                "chart_view": true,
                "axis_x": "packet_size",
                "axis_y": [
                    {
                        "type": [
                            "throughput"
                        ],
                        "keys": {
                            "Side": [
                                "Rx"
                            ]
                        }
                    },
                    {
                        "type": [
                            "pps"
                        ],
                        "keys": {
                            "Side": [
                                "Rx"
                            ]
                        },
                        "aggr": [
                            "mean"
                        ]
                    }
                ],
                "sequence_group_arg": "testpmd_arg_rxq",
                "percentage_base_value": 1,
                "sequence_name_conversion": {},
                "not_show_args": {},
                "records_order": []
            }
        }
    }
}
```
Responce status code: 422

In this case, it is necessary to notify the user about the existence of a configuration with this name and suggest either returning to editing or updating the configuration with the passed name in accordance with the passed data and the data of the current configuration. When selecting the second option, call `POST api/v2/config Body: {<new_config_data>}`.

