### PR TITLE
Urls: fix run source link building

### DIFF
--- a/bublik/core/run/external_links.py
+++ b/bublik/core/run/external_links.py
@@ -37,7 +37,10 @@ def get_sources(result, source=None):
 
         if log and log.reference:
             log_base = log.reference.uri
-            return os.path.join(log_base, log.meta.value)
+            source_tail = log.meta.value
+            if log_base.endswith('/') or source_tail.startswith('/'):
+                return f'{log_base.rstrip("/")}/{source_tail.lstrip("/")}'
+            return log_base + source_tail
 
         return None
 


### PR DESCRIPTION
Since the state of the references may be different, it is necessary to take into account the presence of a slash when source URL is built to avoid double splash and also use a join instead of os.path.join(), since it removes the previous items if the item starts with a slash.