### PR TITLE
Add DRF Spectacular with Swagger and Redoc for API Documentation

### DIFF
--- a/bublik/interfaces/api_v2/config.py
+++ b/bublik/interfaces/api_v2/config.py
@@ -188,8 +188,8 @@ class ConfigViewSet(ModelViewSet):
         return super().destroy(request, *args, **kwargs)
 
     @auth_required(as_admin=True)
-    @action(detail=False, methods=['get'])
-    def schema(self, request, *args, **kwargs):
+    @action(detail=False, methods=['get'], url_path='schema')
+    def get_schema(self, request, *args, **kwargs):
         '''
         Get the JSON schema by passed config type and name.
         Request: GET api/v2/config/get_schema/?type=<config_type>&name=<config_name>.

--- a/bublik/urls.py
+++ b/bublik/urls.py
@@ -5,6 +5,11 @@ from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path, re_path
 from django.views.decorators.cache import cache_page
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
 from rest_framework.routers import DefaultRouter
 
 from bublik.core.routers import ActionsOnlyRouter
@@ -59,6 +64,13 @@ urlpatterns = [
     # V2
     re_path(r'^v2/$', api_v2.render_react, name='ui-v2-index'),
     re_path(r'^v2/(?:.*)/?$', api_v2.render_react, name='ui-v2-routes'),
+    path('api/v2/schema/swagger.yaml/', SpectacularAPIView.as_view(), name='schema'),
+    path(
+        'api/v2/schema/swagger-ui/',
+        SpectacularSwaggerView.as_view(url_name='schema'),
+        name='swagger-ui',
+    ),
+    path('api/v2/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
     path('api/v2/', include((api_v2_router.urls, 'api-v2'), namespace='api-v2')),
     # Redirects
     path('', main_api.redirect_root),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# After adding or removing a dependency, run the following command to sort:
+# `sort -f requirements.txt -o requirements.txt`
 amqp==5.1.1
 appdirs==1.4.3
 asgiref
@@ -19,7 +21,6 @@ coverage==5.3
 cryptography==43.0.3
 deepdiff==6.2.3
 Dickens==2.0.0
-Django==5.1.3
 django-admin==1.3.2
 django-bulk-update==2.2.0
 django-cachalot==2.7.0
@@ -31,8 +32,9 @@ django-lint==2.0.4
 django-redis-cache==3.0.1
 django-six==1.0.4
 django-static-jquery==2.1.4
-djangorestframework==3.15.2
+Django==5.1.3
 djangorestframework-simplejwt
+djangorestframework==3.15.2
 flake8==3.9.2
 flower==2.0.1
 flynt==0.64
@@ -81,8 +83,8 @@ pytz==2024.1
 pytzdata==2020.1
 PyYAML==6.0.1
 redis==3.5.3
-requests==2.32.3
 requests-kerberos==0.15.0
+requests==2.32.3
 ruff
 screen==1.0.1
 shell==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,8 @@ django-static-jquery==2.1.4
 Django==5.1.3
 djangorestframework-simplejwt
 djangorestframework==3.15.2
+drf-spectacular-sidecar==2024.11.1
+drf-spectacular==0.27.2
 flake8==3.9.2
 flower==2.0.1
 flynt==0.64

--- a/templates/settings.py.template
+++ b/templates/settings.py.template
@@ -59,6 +59,8 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework_simplejwt',
     'rest_framework_simplejwt.token_blacklist',
+    'drf_spectacular',
+    'drf_spectacular_sidecar',
 
     'bublik.data',
     'bublik.interfaces',
@@ -242,6 +244,18 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': ('bublik.core.filter_backends.AllDjangoFilterBackend',),
     'DEFAULT_PAGINATION_CLASS': 'bublik.core.pagination.DefaultPageNumberPagination',
     'EXCEPTION_HANDLER': 'bublik.core.exceptions.custom_exception_handler',
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}
+
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Bublik API',
+    'DESCRIPTION': 'Bublik API documentation',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+    'SWAGGER_UI_DIST': 'SIDECAR',  # shorthand to use the sidecar instead
+    'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',
+    'REDOC_DIST': 'SIDECAR',
 }
 
 


### PR DESCRIPTION
## **Description**
This PR introduces DRF Spectacular to generate OpenAPI documentation for our API and integrates Swagger UI and Redoc as interactive documentation tools.  
This is an initial step toward comprehensive API documentation.
With this integration, clients will now be able to generate code in various programming languages to interact with the API, leveraging the OpenAPI schema.


## **Key Changes**
- Added **DRF Spectacular** for OpenAPI schema generation.
- Configured **Swagger UI** and **Redoc** for visualising and exploring the API.
- Integrated schema URLs:
  - Swagger: `/schema/swagger-ui/`
  - Redoc: `/schema/redoc/`
  - Schema: `/schema/swagger.yaml`
- Adjusted viewsets to ensure schema generation works without errors (e.g., adding queryset handling and filter overrides for unsupported fields like `JSONField`).

## **Next Steps**
- New endpoints should include detailed API documentation using DRF Spectacular decorators such as:
  - `@extend_schema`
  - `@extend_schema_field`
- Incrementally document existing endpoints to ensure consistency and clarity across the API.

## **How to Test**
1. Ensure you installed new dependencies.
2. Ensure you have updated `settings.py` with drf-spectacular settings added
3. Navigate to:
   - **Swagger UI**: `/api/v2/schema/swagger-ui/`
   - **Redoc**: `/api/v2/schema/redoc`
4. Verify that all currently documented endpoints are correctly listed and functional in both Swagger and Redoc.
