### PR TITLE
Update the import, storage and representation of measurement results

### DIFF
--- a/bublik/core/importruns/milog.py
+++ b/bublik/core/importruns/milog.py
@@ -165,18 +165,19 @@ class EntryLevel(InstanceLevel, Saver):
         InstanceLevel.__init__(self, entry, self.meta_type)
         Saver.__init__(self, self.parent.parent.data + self.parent.data + self.data)
 
-    def save(self, test_iter_result):
+    def get_measurement(self):
         self.counter['meas_obj'] += 1
-
         measure_serializer = serialize(MeasurementSerializer, {'metas': self.metas}, logger)
-
         measurement, created = measure_serializer.get_or_create()
         if created:
             self.counter['created_meas_obj'] += 1
-
         if measurement not in self.measurements:
             self.measurements.append(measurement)
 
+        return measurement
+
+    def save(self, test_iter_result):
+        measurement = self.get_measurement()
         try:
             mr = MeasurementResult.objects.get(
                 measurement=measurement,

--- a/bublik/core/importruns/milog.py
+++ b/bublik/core/importruns/milog.py
@@ -5,6 +5,7 @@ from collections import Counter
 from datetime import datetime, timedelta
 import json
 import logging
+from typing import ClassVar
 
 from bublik.core.shortcuts import serialize
 from bublik.data.models import (
@@ -30,7 +31,7 @@ class Saver:
     the Saver class, It should also implement the save() method.
     '''
 
-    measurements = []
+    measurements: ClassVar[list] = []
 
     def __init__(self, metas):
         self.metas = metas
@@ -104,18 +105,18 @@ class InstanceLevel:
 
 
 class CommonLevel(InstanceLevel):
-    key_dict_to_meta_type = {
+    key_dict_to_meta_type: ClassVar[dict] = {
         'keys': 'measurement_key',
         'comments': 'measurement_comment',
     }
 
-    key_to_meta_type = {
+    key_to_meta_type: ClassVar[dict] = {
         'tool': 'tool',
         'type': 'note',
         'version': 'note',
     }
 
-    required_constants = {'type': 'measurement', 'version': '1'}
+    required_constants: ClassVar[dict] = {'type': 'measurement', 'version': '1'}
 
     def __init__(self, mi_log):
         self.is_mi_log_valid(mi_log)
@@ -153,7 +154,7 @@ class ResultLevel(InstanceLevel):
 
 class EntryLevel(InstanceLevel, Saver):
     meta_type = 'measurement_subject'
-    counter = Counter()
+    counter: ClassVar[Counter] = Counter()
 
     def __init__(self, entry, serial, parent: ResultLevel):
         value = InstanceLevel.pop(entry, 'value', True)

--- a/bublik/core/importruns/milog.py
+++ b/bublik/core/importruns/milog.py
@@ -221,7 +221,7 @@ class ViewValueLevel(InstanceLevel, Saver):
         Saver.__init__(self, parent.data)
 
     def save(self, test_iter_result, view_type):
-        if self.find_measurement_count == 0 and self.find_measurement is not None:
+        if self.find_measurement is None:
             msg = f'Failed to found result for {self.parent} for {view_type}'
             raise ValueError(msg)
 

--- a/bublik/core/importruns/milog.py
+++ b/bublik/core/importruns/milog.py
@@ -232,7 +232,7 @@ class ViewValueLevel(InstanceLevel, Saver):
         view_serializer = serialize(ViewSerializer, {'metas': self.metas}, logger)
         view, _ = view_serializer.get_or_create()
 
-        ChartView.objects.create(
+        ChartView.objects.get_or_create(
             view=view,
             measurement=self.find_measurement,
             result=test_iter_result,

--- a/bublik/core/measurement/representation.py
+++ b/bublik/core/measurement/representation.py
@@ -182,7 +182,7 @@ class ChartViewBuilder:
             if label_items['sequense_group_arg']
             else None,
             'tool': f': based on {label_items["tool"]}' if label_items['tool'] else None,
-            'keys': f' ({(", ".join(label_items["keys"]))})' if label_items['keys'] else None,
+            'keys': f'({(", ".join(label_items["keys"]))})' if label_items['keys'] else None,
         }
 
         return ' '.join(

--- a/bublik/core/measurement/representation.py
+++ b/bublik/core/measurement/representation.py
@@ -39,7 +39,7 @@ class ChartViewBuilder:
     def by_line_graph(cls, cv: ChartView):
         view = cv.view
         measurement = cv.measurement
-        measurement_results = get_measurement_results([cv.result], measurement)
+        measurement_results = get_measurement_results([cv.result.id], measurement)
         return cls(view, measurement, measurement_results)
 
     @classmethod

--- a/bublik/core/measurement/services.py
+++ b/bublik/core/measurement/services.py
@@ -14,25 +14,26 @@ from bublik.data.models import (
 logger = logging.getLogger('bublik.server')
 
 
-def get_measurements_by_result(result_id):
+def get_measurement_results(result_ids, measurement=None):
     # TODO type processing
-    return MeasurementResult.objects.filter(result__id=result_id).select_related(
-        'measurement',
-        'result',
-        'result__iteration',
-        'result__iteration__test',
+    measurement_results = (
+        MeasurementResult.objects.filter(result__id__in=result_ids)
+        .order_by('measurement__id')
+        .select_related(
+            'measurement',
+            'result',
+            'result__test_run',
+            'result__iteration',
+            'result__iteration__test',
+        )
     )
-
-
-def get_measurement_results(iteration_results, measurement):
-    return MeasurementResult.objects.filter(
-        result__in=iteration_results,
-        measurement=measurement,
-    ).select_related('result', 'result__iteration')
+    if measurement:
+        return measurement_results.filter(measurement=measurement)
+    return measurement_results
 
 
 def get_measurement_results_or_none(result_id):
-    data = get_measurements_by_result(result_id)
+    data = get_measurement_results([result_id])
     if not data:
         return None
     measurement_results = []

--- a/bublik/core/measurement/services.py
+++ b/bublik/core/measurement/services.py
@@ -47,8 +47,8 @@ def exist_measurement_results(test_result):
     return test_result.measurement_results.exists()
 
 
-def get_chart_views(results_ids):
-    return ChartView.objects.filter(result_id__in=results_ids).select_related(
+def get_chart_views(result_ids):
+    return ChartView.objects.filter(result_id__in=result_ids).select_related(
         'view',
         'measurement',
     )
@@ -95,10 +95,10 @@ def merge_measurements(data):
     return final_data
 
 
-def represent_measurements(results_ids):
-    logger.debug('[represent_measurements]: start for %d ids', len(results_ids))
+def represent_measurements(result_ids):
+    logger.debug('[represent_measurements]: start for %d ids', len(result_ids))
     mmrs = list(
-        MeasurementResult.objects.filter(result__in=results_ids).order_by('measurement__id')
+        MeasurementResult.objects.filter(result__in=result_ids).order_by('measurement__id')
         # we need all the related fields because final json gives information
         # about result and run so that UI is able to provide convenient links to
         # the user
@@ -163,7 +163,7 @@ def represent_measurements(results_ids):
 
         data.append(mm_data)
 
-    if len(results_ids) > 1:
+    if len(result_ids) > 1:
         data = merge_measurements(data)
     logger.debug('[represent_measurements]: completed, data len = %d', len(data))
 

--- a/bublik/core/measurement/services.py
+++ b/bublik/core/measurement/services.py
@@ -1,19 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
-from itertools import groupby
-import logging
-
 from bublik.data.models import (
     ChartView,
     ChartViewType,
+    Measurement,
     MeasurementResult,
     MeasurementResultList,
     View,
 )
-
-
-logger = logging.getLogger('bublik.server')
 
 
 def get_measurement_results(result_ids, measurement=None):
@@ -43,6 +38,12 @@ def get_measurement_result_lists(result_id, measurement=None):
     return measurement_result_lists
 
 
+def get_measurements(result_ids):
+    return Measurement.objects.filter(measurement_results__result__id__in=result_ids).distinct(
+        'id',
+    )
+
+
 def get_measurement_results_or_none(result_id):
     data = get_measurement_results([result_id])
     if not data:
@@ -70,131 +71,15 @@ def get_point_views(views):
     return views.filter(metas__value='point')
 
 
-def get_chart_views(result_ids, view=None):
+def get_chart_views(result_id, view):
     return (
-        ChartView.objects.filter(result_id__in=result_ids, view=view)
+        ChartView.objects.filter(result_id=result_id, view=view)
         .select_related(
             'view',
             'measurement',
         )
         .distinct('id')
     )
-
-
-def merge_measurements(data):
-    # The results of measurements that differ from each other only
-    # by the value of comments should be analyzed together,
-    # since comments is not the key information.
-    # Thus, the charts corresponding to such measurements
-    # need to be merged.
-    final_data = []
-    data_num = len(data)
-    for _num in range(data_num):
-        if len(data) > 0:
-            final_d = data.pop(0)
-            for dot in final_d['dots']:
-                dot['comments'] = final_d['comments']
-
-            data_copy = data.copy()
-            for d in data_copy:
-                if all(
-                    final_d[k] == d[k]
-                    for k in final_d
-                    if k not in ('measurement_id', 'comments', 'dots')
-                ):
-                    for dot in d['dots']:
-                        dot['comments'] = d['comments']
-                    final_d['dots'].extend(d['dots'])
-                    data.remove(d)
-
-            final_d.pop('measurement_id')
-            final_d.pop('comments')
-            final_d['dots'].sort(key=lambda dot: dot['start'])
-
-            final_data.append(final_d)
-        else:
-            break
-
-    # sort so that the charts containing the newest results
-    # are shown first
-    final_data.sort(key=lambda measurement: measurement['dots'][-1]['start'], reverse=True)
-
-    return final_data
-
-
-def represent_measurements(result_ids):
-    logger.debug('[represent_measurements]: start for %d ids', len(result_ids))
-    mmrs = list(
-        MeasurementResult.objects.filter(result__in=result_ids).order_by('measurement__id')
-        # we need all the related fields because final json gives information
-        # about result and run so that UI is able to provide convenient links to
-        # the user
-        .select_related('measurement', 'result', 'result__test_run', 'result__iteration'),
-    )
-    logger.debug(
-        '[represent_measurements]: collected %d measurement results from DB',
-        len(mmrs),
-    )
-
-    def measurements_grouper(mmr):
-        return mmr.measurement.id
-
-    data = []
-    logger.debug(
-        '[represent_measurements]: Number of measurement groups: %d',
-        len(list(groupby(mmrs, key=measurements_grouper))),
-    )
-    for _measurement_id, mmrs_groups in groupby(mmrs, key=measurements_grouper):
-        mmrs_groups_list = list(mmrs_groups)
-        measurement = mmrs_groups_list[0].measurement
-
-        mm_data = measurement.representation()
-        mm_data['dots'] = [
-            mmr.representation() for mmr in mmrs_groups_list
-        ]
-
-        title_items = []
-        if mm_data['name']:
-            title_items.append(mm_data['name'].capitalize())
-        else:
-            title_items.append(mm_data['tool'].capitalize())
-        if mm_data['aggr']:
-            title_items.append(mm_data['aggr'].capitalize())
-        if mm_data['keys']:
-            title_items.append(', '.join(mm_data['keys']))
-
-        config = {
-            'title': ' - '.join(title_items),
-            'default_x': 'start',
-            'default_y': 'value',
-            'getters': ['start', 'value', 'sequence_number'],
-            'axises': {
-                'start': {
-                    'getter': 'start',
-                    'label': 'Start of measurement test',
-                    'units': 'timestamp',
-                },
-                'sequence_number': {
-                    'getter': 'sequence_number',
-                    'label': 'Sequence Number',
-                    'units': '',
-                },
-                'value': {
-                    'getter': 'value',
-                    'label': mm_data['type'],
-                    'units': 'units',
-                },
-            },
-        }
-        mm_data['axises_config'] = config
-
-        data.append(mm_data)
-
-    if len(result_ids) > 1:
-        data = merge_measurements(data)
-    logger.debug('[represent_measurements]: completed, data len = %d', len(data))
-
-    return data
 
 
 def get_x_chart_view(line_chart_views):
@@ -206,13 +91,4 @@ def get_x_chart_view(line_chart_views):
 def get_y_chart_views(line_chart_views):
     return line_chart_views.filter(
         type=ChartViewType.conv(ChartViewType.AXIS_Y),
-    )
-
-
-def get_points_chart_views(chart_views):
-    # Get point chart views where result has one measurement
-    # and build line-graph thought different runs with the same measurement
-    return chart_views.filter(
-        view__metas__value='point',
-        type=ChartViewType.conv(ChartViewType.POINT),
     )

--- a/bublik/core/report/components.py
+++ b/bublik/core/report/components.py
@@ -38,7 +38,7 @@ class ReportPoint:
         self.args_vals = {}
 
         # get sequences level data
-        self.sequence_group_arg = self.test_config.get('sequences', {}).get('arg', None)
+        sequence_group_arg = self.test_config.get('sequences', {}).get('arg', None)
         self.sequence_group_arg_val = None
 
         # get measurements level data
@@ -55,10 +55,19 @@ class ReportPoint:
             if arg.name == self.axis_x_arg:
                 axis_x_value = type_conversion(arg.value)
                 value = mmr.value
-            elif arg.name == self.sequence_group_arg:
+            elif arg.name == sequence_group_arg:
                 self.sequence_group_arg_val = type_conversion(arg.value)
             elif arg.name not in common_args[self.test_name]:
                 self.args_vals[arg.name] = type_conversion(arg.value)
+
+        # check iteration
+        warnings = []
+        if axis_x_value is None:
+            warnings.append(f'The test has no argument {self.axis_x_arg}')
+        if sequence_group_arg is not None and self.sequence_group_arg_val is None:
+            warnings.append(f'The test has no argument {sequence_group_arg}')
+        if warnings:
+            raise ValueError(warnings)
 
         # handle argument values (sort and build label)
         self.sort_arg_vals()

--- a/bublik/core/report/components.py
+++ b/bublik/core/report/components.py
@@ -1,16 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
 
-import contextlib
-import copy
-
 from itertools import groupby
 
-from bublik.core.report.services import (
-    get_labels,
-    sequence_name_conversion,
-    type_conversion,
-)
+from bublik.core.measurement.representation import ReportRecordBuilder
+from bublik.core.report.services import type_conversion
 
 
 '''
@@ -21,8 +15,7 @@ The report has four levels of nesting:
    units of measurement).
 4. Record level. It contains records (tables and/or charts with measurement results).
    The points on each of the record are combined into sequences according to the value of one
-   specific argument and regrouped into datasets according to axis x values
-   (more convenient for UI).
+   specific argument.
 '''
 
 
@@ -37,30 +30,35 @@ class ReportPoint:
         Build the point object based on the measurement result
         according to report config.
         '''
+        # get test level data
         self.test_name = mmr.result.iteration.test.name
         self.test_config = report_config['tests'][self.test_name]
 
+        # get argument values level data
         self.args_vals = {}
-        self.axis_x = self.test_config['axis_x']['arg']
-        sequences = self.test_config.get('sequences', {})
-        self.sequence_group_arg = sequences.get('arg', None)
-        sequence_group_arg_label = sequences.get('arg_label', None)
-        self.sequence_group_arg_val = None
-        self.point = {}
 
-        # collect test arguments values, value of sequence argument and the point
+        # get sequences level data
+        self.sequence_group_arg = self.test_config.get('sequences', {}).get('arg', None)
+        self.sequence_group_arg_val = None
+
+        # get measurements level data
+        self.measurement_id = mmr.measurement.id
+        self.measurement = mmr.measurement
+
+        # get x-axis data
+        self.axis_x_arg = self.test_config['axis_x']['arg']
+        axis_x_value = None
+        value = None
+
+        # collect test argument values, value of sequence argument and the point
         for arg in mmr.result.iteration.test_arguments.all():
-            if arg.name == self.axis_x:
-                self.point[type_conversion(arg.value)] = mmr.value
+            if arg.name == self.axis_x_arg:
+                axis_x_value = type_conversion(arg.value)
+                value = mmr.value
             elif arg.name == self.sequence_group_arg:
-                # ID is needed to maintain order when sorting before
-                # it is grouped in the future
-                self.sequence_group_arg_val = (
-                    arg.id,
-                    sequence_name_conversion(arg.value, self.test_config),
-                )
+                self.sequence_group_arg_val = type_conversion(arg.value)
             elif arg.name not in common_args[self.test_name]:
-                self.args_vals[arg.name] = arg.value
+                self.args_vals[arg.name] = type_conversion(arg.value)
 
         # handle argument values (sort and build label)
         self.sort_arg_vals()
@@ -68,8 +66,16 @@ class ReportPoint:
             [f'{arg}: {val}' for arg, val in self.args_vals.items()],
         )
 
-        # get the measurement block label and the y-axis label
-        self.measurement_label, self.axis_y_label = get_labels(mmr, sequence_group_arg_label)
+        # set point
+        self.point = {
+            axis_x_value: {
+                'y_value': value,
+                'metadata': {
+                    'iteration_id': mmr.result.iteration.id,
+                    'result_id': mmr.result.id,
+                },
+            },
+        }
 
     def sort_arg_vals(self):
         '''
@@ -85,6 +91,19 @@ class ReportPoint:
         else:
             self.args_vals = dict(sorted(self.args_vals.items()))
 
+    @staticmethod
+    def by_test_name_sort(by_test_name_points, ordered_test_names):
+        '''
+        Return groups of points by name, sorted according to the configuration.
+        '''
+        by_test_name_points_sorted = {
+            test_name: by_test_name_points[test_name]
+            for test_name in ordered_test_names
+            if test_name in by_test_name_points
+        }
+        by_test_name_points_sorted.update(by_test_name_points)
+        return by_test_name_points_sorted
+
     def points_grouper_tests(self):
         return self.test_name
 
@@ -92,180 +111,7 @@ class ReportPoint:
         return self.arg_val_label
 
     def points_grouper_measurements(self):
-        return self.measurement_label
-
-    def points_grouper_records(self):
-        return self.axis_y_label
-
-    def points_grouper_sequences(self):
-        return self.sequence_group_arg_val
-
-
-class ReportRecordLevel:
-    '''
-    This class describes the report blocks corresponding to the records (charts and/or tables).
-    '''
-
-    def __init__(self, test_name, meas_lvl_id, axis_y_label, record_points, report_config):
-        test_config = report_config['tests'][test_name]
-        table_view = test_config['table_view']
-        chart_view = test_config['chart_view']
-
-        self.type = 'record-block'
-        self.warnings = []
-        self.multiple_sequences = bool('sequences' in test_config)
-
-        self.axis_x_label = test_config['axis_x'].get(
-            'label',
-            test_config['axis_x']['arg'],
-        )
-
-        if self.multiple_sequences:
-            sequence_group_arg_label = test_config['sequences'].get(
-                'arg_label',
-                test_config['sequences']['arg'],
-            )
-            self.axis_x_key = f'{self.axis_x_label} / {sequence_group_arg_label}'
-        else:
-            self.axis_x_key = f'{self.axis_x_label}'
-
-        self.axis_y_label = axis_y_label
-        self.id = f'{meas_lvl_id}_{self.axis_y_label}'
-
-        if table_view or chart_view:
-            # create datasets
-            if not self.multiple_sequences:
-                dataset_labels = [self.axis_x_key, self.axis_y_label]
-                dataset_data = []
-                for record_point in list(record_points):
-                    for arg, val in record_point.point.items():
-                        dataset_data.append([arg, val])
-                with contextlib.suppress(TypeError):
-                    dataset_data = sorted(dataset_data)
-            else:
-                # group points into sequences
-                sequences = self.get_sequences(record_points)
-                # create datasets by sequences
-                dataset_labels, dataset_data = self.create_dataset(sequences, test_config)
-        if table_view:
-            self.dataset_table = self.get_dataset_table(
-                dataset_labels,
-                dataset_data,
-                test_config,
-            )
-        if chart_view:
-            self.dataset_chart = self.get_dataset_chart(dataset_labels, dataset_data)
-
-    def get_sequences(self, record_points):
-        '''
-        Group points into sequences.
-        '''
-        sequences = {}
-        record_points = sorted(record_points, key=ReportPoint.points_grouper_sequences)
-        for seq_arg_id_and_val, sequence_points in groupby(
-            record_points,
-            ReportPoint.points_grouper_sequences,
-        ):
-            sequence_group_arg_val = seq_arg_id_and_val[1]
-            # add points to the corresponding sequence
-            sequence = {}
-            for sequence_point in list(sequence_points):
-                for arg, val in sequence_point.point.items():
-                    sequence[arg] = val
-            sequences[sequence_group_arg_val] = sequence
-        return sequences
-
-    def complete_sequences(self, sequences):
-        axis_x_vals = set()
-        for _, sequence in sequences.items():
-            for k in sequence:
-                axis_x_vals.add(k)
-
-        for sequence_group_arg_val, sequence in sequences.items():
-            for k in axis_x_vals:
-                if k not in sequence:
-                    sequences[sequence_group_arg_val][k] = '-'
-
-    def create_dataset(self, sequences, test_config):
-        '''
-        Regroup points into datasets that are more convenient for UI.
-        '''
-        self.complete_sequences(sequences)
-        dataset_data = []
-        for axis_x_val in next(iter(sequences.values())):
-            dataset_data.append([axis_x_val])
-        dataset_labels = [self.axis_x_key]
-        for sequence_group_arg_val, sequence in sequences.items():
-            dataset_labels.append(
-                sequence_name_conversion(sequence_group_arg_val, test_config),
-            )
-            for i, point in enumerate(sequence.values()):
-                dataset_data[i].append(point)
-        return dataset_labels, dataset_data
-
-    def percentage_calc(self, dataset_labels, dataset_data, test_config):
-        '''
-        Calculate gain relative to "base" sequence.
-        '''
-        dataset_labels = copy.deepcopy(dataset_labels)
-        dataset_data = copy.deepcopy(dataset_data)
-
-        percentage_base_value = test_config['sequences']['percentage_base_value']
-        percentage_base_value = sequence_name_conversion(percentage_base_value, test_config)
-
-        if percentage_base_value in dataset_labels:
-            self.formatters = {}
-            pbv_idx = dataset_labels.index(percentage_base_value)
-            for dataset_label in dataset_labels[1:]:
-                if dataset_label != percentage_base_value:
-                    dataset_label_gain = f'{dataset_label} gain'
-                    dataset_labels.append(dataset_label_gain)
-                    self.formatters[dataset_label_gain] = '%'
-                    idx = dataset_labels.index(dataset_label)
-                    for dataset_item in dataset_data:
-                        try:
-                            percentage = round(
-                                100 * (dataset_item[idx] / dataset_item[pbv_idx] - 1),
-                                2,
-                            )
-                        except ZeroDivisionError:
-                            percentage = 'na'
-                        except TypeError:
-                            percentage = '-'
-                        dataset_item.append(percentage)
-        else:
-            self.warnings.append(
-                f'There is no sequence corresponding to the passed '
-                f'base value {percentage_base_value}. '
-                'Persentage calculation is skipped.',
-            )
-
-        return dataset_labels, dataset_data
-
-    def get_dataset_table(self, dataset_labels, dataset_data, test_config):
-        if self.multiple_sequences and 'percentage_base_value' in test_config['sequences']:
-            dataset_labels, dataset_data = self.percentage_calc(
-                dataset_labels,
-                dataset_data,
-                test_config,
-            )
-        with contextlib.suppress(TypeError):
-            dataset_data = sorted(dataset_data)
-        return [dataset_labels, *dataset_data]
-
-    def get_dataset_chart(self, dataset_labels, dataset_data):
-        dataset_chart_data = []
-        for dataset_item in dataset_data:
-            # include in the chart dataset only those results that correspond
-            # to the numeric values of the x-axis argument
-            if not isinstance(dataset_item[0], int):
-                self.warnings.append(
-                    f'The results corresponding to {dataset_labels[0]}={dataset_item[0]} '
-                    'cannot be displayed on the chart',
-                )
-            else:
-                dataset_chart_data.append(dataset_item)
-        return [dataset_labels, *sorted(dataset_chart_data)]
+        return self.measurement_id
 
 
 class ReportMeasurementLevel:
@@ -275,34 +121,19 @@ class ReportMeasurementLevel:
 
     def __init__(
         self,
-        test_name,
         av_lvl_id,
-        measurement_info,
-        measurement_points,
-        report_config,
+        subtitle,
+        records,
     ):
         self.type = 'measurement-block'
-        self.label = measurement_info
-        self.id = '_'.join([av_lvl_id, self.label.replace(' ', '')])
+        self.label = subtitle
+        self.id = '_'.join([av_lvl_id, '-'.join([str(record.id) for record in records])])
         self.content = []
 
-        measurement_points = sorted(
-            measurement_points,
-            key=ReportPoint.points_grouper_records,
-        )
-
-        for axis_y_label, record_points in groupby(
-            measurement_points,
-            ReportPoint.points_grouper_records,
-        ):
-            record = ReportRecordLevel(
-                test_name,
-                self.id,
-                axis_y_label,
-                list(record_points),
-                report_config,
-            )
-            self.content.append(record.__dict__)
+        for record in records:
+            record_data = record.representation()
+            record_data.update({'id': '_'.join([self.id, str(record.id)])})
+            self.content.append(record_data)
 
 
 class ReportArgsValsLevel:
@@ -318,23 +149,25 @@ class ReportArgsValsLevel:
         self.id = '_'.join([test_lvl_id, self.label.replace(' ', '')])
         self.content = []
 
-        arg_val_record_points = sorted(
-            arg_val_record_points,
-            key=ReportPoint.points_grouper_measurements,
-        )
-
-        for measurement_info, measurement_points in groupby(
+        # create measurement records
+        records = []
+        for _measurement_id, measurement_points in groupby(
             arg_val_record_points,
             ReportPoint.points_grouper_measurements,
         ):
-            measurement_record = ReportMeasurementLevel(
-                test_name,
-                self.id,
-                measurement_info,
-                list(measurement_points),
-                report_config,
+            points = measurement_points
+            records.append(
+                ReportRecordBuilder(
+                    next(iter(points)).measurement,
+                    report_config['tests'][test_name],
+                    points,
+                ),
             )
-            self.content.append(measurement_record.__dict__)
+
+        # group measurement records by measurement chart labels
+        records_by_subtitles = ReportRecordBuilder.group_by_subtitle(records)
+        for subtitle, records in records_by_subtitles.items():
+            self.content.append(ReportMeasurementLevel(self.id, subtitle, records).__dict__)
 
 
 class ReportTestLevel:
@@ -354,7 +187,6 @@ class ReportTestLevel:
         self.content = []
 
         test_points = sorted(test_points, key=ReportPoint.points_grouper_args_vals)
-
         for _, arg_val_record_points in groupby(
             test_points,
             ReportPoint.points_grouper_args_vals,

--- a/bublik/core/report/services.py
+++ b/bublik/core/report/services.py
@@ -65,16 +65,6 @@ def args_type_convesion(point_groups_by_test_name):
     return point_groups_by_test_name
 
 
-def args_sort(records_order, args_vals):
-    if records_order:
-        args_vals_sorted = {arg: args_vals[arg] for arg in records_order if arg in args_vals}
-        args_vals_other = {
-            arg: val for arg, val in args_vals.items() if arg not in args_vals_sorted
-        }
-        return args_vals_sorted | args_vals_other
-    return dict(sorted(args_vals.items()))
-
-
 def get_common_args(main_pkg, test_name):
     '''
     Collect arguments that have the same values for all iterations of the test

--- a/bublik/core/report/services.py
+++ b/bublik/core/report/services.py
@@ -4,7 +4,7 @@
 import contextlib
 from itertools import groupby
 
-from bublik.core.measurement.representation import ChartViewBuilder
+from bublik.core.measurement.representation import AxisRepresentationBuilder, ChartViewBuilder
 from bublik.data.models import MeasurementResult, TestArgument
 
 
@@ -15,12 +15,12 @@ def get_labels(mmr, sequence_group_arg):
     - measurement label = "<measurement type> (<measurement units>, <measurement aggr>)
       by <sequence group arg>: based on <measurement tool>".
     '''
-    measurement_data = mmr.measurement.representation()
+    measurement = mmr.measurement
     measurement_label = ChartViewBuilder.get_measurement_chart_label(
-        measurement_data,
+        measurement.representation(),
         sequence_group_arg,
     )
-    axis_y_label = ChartViewBuilder.get_measurement_axis_label(measurement_data)
+    axis_y_label = AxisRepresentationBuilder(measurement).to_representation()['label']
 
     return measurement_label, axis_y_label
 

--- a/bublik/core/report/services.py
+++ b/bublik/core/report/services.py
@@ -95,34 +95,3 @@ def filter_by_not_show_args(mmrs_test, not_show_args):
         not_show_mmrs = not_show_mmrs.union(arg_vals_mmrs)
 
     return mmrs_test.difference(not_show_mmrs)
-
-
-def get_unprocessed_iter_info(point, common_args):
-    '''
-    Get information about an unprocessed iteration with the reasons why it cannot be processed.
-    '''
-    point = point.__dict__
-    invalid_iteration = {
-        'test_name': point['test_name'],
-        'common_args': common_args[point['test_name']],
-        'args_vals': point['args_vals'],
-        'reasons': [],
-    }
-    if point['sequence_group_arg']:
-        if not point['sequence_group_arg_val']:
-            invalid_iteration['reasons'].append(
-                f'The test has no argument {point["sequence_group_arg"]}',
-            )
-        else:
-            invalid_iteration['args_vals'][point['sequence_group_arg']] = point[
-                'sequence_group_arg_val'
-            ]
-    axis_x_arg = point['axis_x_arg']
-    axis_x_value = next(iter(point['point'].keys()))
-    if not axis_x_value:
-        invalid_iteration['reasons'].append(
-            f'The test has no argument {axis_x_arg}',
-        )
-    else:
-        invalid_iteration['args_vals'][axis_x_arg] = axis_x_value
-    return invalid_iteration

--- a/bublik/data/models/__init__.py
+++ b/bublik/data/models/__init__.py
@@ -30,6 +30,7 @@ from .measurement import (
     ChartViewType,
     Measurement,
     MeasurementResult,
+    MeasurementResultList,
     View,
 )
 from .meta import (
@@ -87,4 +88,5 @@ __all__ = [
     'ConfigTypes',
     'GlobalConfigNames',
     'Config',
+    'MeasurementResultList',
 ]

--- a/bublik/data/models/measurement.py
+++ b/bublik/data/models/measurement.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
+from typing import ClassVar
+
 from django.db import models
 
 from bublik.core.utils import get_metric_prefix_units, key_value_transforming
@@ -27,9 +29,9 @@ class ChartViewType:
     AXIS_Y = 'axis_y'
     POINT = 'point'
 
-    SET = {AXIS_X: 'X', AXIS_Y: 'Y', POINT: 'P'}
+    SET: ClassVar[dict] = {AXIS_X: 'X', AXIS_Y: 'Y', POINT: 'P'}
 
-    INV_SET = {v: k for k, v in SET.items()}
+    INV_SET: ClassVar[dict] = {v: k for k, v in SET.items()}
 
     @classmethod
     def conv(cls, item):

--- a/bublik/data/models/measurement.py
+++ b/bublik/data/models/measurement.py
@@ -3,6 +3,7 @@
 
 from typing import ClassVar
 
+from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
 from bublik.core.utils import get_metric_prefix_units, key_value_transforming
@@ -142,6 +143,34 @@ Serial number can be used to determine results order.''',
             'result_id': self.result.id,
             'iteration_id': self.result.iteration.id,
         }
+
+
+class MeasurementResultList(models.Model):
+    '''
+    The table to store sequences of measurement results.
+    '''
+
+    measurement = models.ForeignKey(
+        Measurement,
+        on_delete=models.CASCADE,
+        help_text='The measurement characteristics.',
+    )
+    value = ArrayField(models.FloatField(), help_text='The measurement values of the result')
+    result = models.ForeignKey(
+        TestIterationResult,
+        on_delete=models.CASCADE,
+        help_text='The test iteration result which is measured.',
+    )
+    serial = models.IntegerField(
+        default=0,
+        help_text='Serial number can be used to determine results order',
+    )
+
+    class Meta:
+        db_table = 'bublik_measurementresultlist'
+
+    def __len__(self):
+        return len(self.value)
 
 
 class View(models.Model):

--- a/bublik/data/models/measurement.py
+++ b/bublik/data/models/measurement.py
@@ -134,7 +134,11 @@ Serial number can be used to determine results order.''',
     class Meta:
         db_table = 'bublik_measurementresult'
 
-    def representation(self):
+    def representation(self, additional='result'):
+        if additional == 'measurement':
+            mmr_repr = self.measurement.representation()
+            mmr_repr.update({'value': self.value})
+            return mmr_repr
         return {
             'start': self.result.start,
             'sequence_number': self.serial,

--- a/bublik/data/models/measurement.py
+++ b/bublik/data/models/measurement.py
@@ -176,6 +176,20 @@ class MeasurementResultList(models.Model):
     def __len__(self):
         return len(self.value)
 
+    def representation(self, additional='result'):
+        if additional == 'measurement':
+            mmr_repr = self.measurement.representation()
+            mmr_repr.update({'value': self.value})
+            return mmr_repr
+        return {
+            'start': self.result.start,
+            'sequence_number': self.serial,
+            'value': self.value,
+            'run_id': self.result.test_run.id,
+            'result_id': self.result.id,
+            'iteration_id': self.result.iteration.id,
+        }
+
 
 class View(models.Model):
     '''

--- a/bublik/data/serializers/__init__.py
+++ b/bublik/data/serializers/__init__.py
@@ -18,6 +18,7 @@ from .expectation import (
     ExpectMetaWriteSerializer,
 )
 from .measurement import (
+    MeasurementResultListSerializer,
     MeasurementResultSerializer,
     MeasurementSerializer,
     ViewSerializer,
@@ -60,4 +61,5 @@ __all__ = [
     'EndpointURLSerializer',
     'MetaTestSerializer',
     'ConfigSerializer',
+    'MeasurementResultListSerializer',
 ]

--- a/bublik/interfaces/api_v2/measurements.py
+++ b/bublik/interfaces/api_v2/measurements.py
@@ -35,11 +35,11 @@ class MeasurementViewSet(GenericViewSet):
 
     @action(detail=False, methods=['post'])
     def by_result_ids(self, request):
-        results_ids = request.data.get('results_ids', None)
-        if not results_ids:
+        result_ids = request.data.get('result_ids', None)
+        if not result_ids:
             return Response({'error': 'No results ids specified'})
 
-        chart_views = get_chart_views(results_ids)
+        chart_views = get_chart_views(result_ids)
 
         if chart_views:
             chart_views_lines = get_lines_chart_views(chart_views)
@@ -70,7 +70,7 @@ class MeasurementViewSet(GenericViewSet):
 
             data = charts_from_lines + charts_from_points
         else:
-            data = represent_measurements(results_ids)
+            data = represent_measurements(result_ids)
 
         return Response(data)
 

--- a/bublik/interfaces/api_v2/measurements.py
+++ b/bublik/interfaces/api_v2/measurements.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
-from itertools import groupby
 import typing
 
 from rest_framework import status
@@ -10,12 +9,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from bublik.core.measurement.representation import ChartViewBuilder
-from bublik.core.measurement.services import (
-    get_chart_views,
-    get_points_chart_views,
-    get_y_chart_views,
-    represent_measurements,
-)
+from bublik.core.measurement.services import get_measurements
 from bublik.data.models import Measurement
 from bublik.data.serializers import MeasurementSerializer
 
@@ -43,42 +37,24 @@ class MeasurementViewSet(GenericViewSet):
                 data={'type': 'ValueError', 'message': 'No result IDs specified'},
             )
 
-        chart_views = get_chart_views(result_ids)
+        measurements = get_measurements(result_ids)
+        charts = [
+            ChartViewBuilder(measurement).by_measurement_results(result_ids)
+            for measurement in measurements
+        ]
+        # The results of measurements that differ from each other only
+        # by the value of comments should be analyzed together,
+        # since comments is not the key information.
+        # Thus, the charts corresponding to such measurements
+        # need to be merged.
+        merge_mm_key = [
+            key
+            for key in next(iter(measurements)).representation()
+            if key not in ['measurement_id', 'comments']
+        ]
+        merged_charts = ChartViewBuilder.merge_charts_by(charts, merge_mm_key)
 
-        if chart_views:
-            chart_views_lines = get_y_chart_views(chart_views).filter(
-                view__metas__value='line-graph',
-            )
-            chart_views_points = get_points_chart_views(chart_views)
-
-            # Get charts from processing line graph chart views
-            charts_from_lines = []
-            for line_chart_view in chart_views_lines:
-                chart = ChartViewBuilder.by_lines(line_chart_view)
-                charts_from_lines.append(chart.representation())
-
-            # Get charts from processing point chart views
-            # Need to group chart_views_points by measurements to make line-graphs from them
-            def grouper_by_measurement(cv):
-                return cv.measurement.id
-
-            charts_from_points = []
-            chart_views_sorted = sorted(chart_views_points, key=grouper_by_measurement)
-            for _measurement_id, points_chart_views in groupby(
-                chart_views_sorted,
-                key=grouper_by_measurement,
-            ):
-                chart = ChartViewBuilder.by_points(points_chart_views)
-                charts_from_points.append(chart)
-                # Make ChartViewBuilder process point chart view as well:
-                # - init by CV line object | list of CV point objects ->
-                # -> ChartViewBuilder.by_points(cvs)
-
-            data = charts_from_lines + charts_from_points
-        else:
-            data = represent_measurements(result_ids)
-
-        return Response(data)
+        return Response([merged_chart.representation() for merged_chart in merged_charts])
 
     def retrieve(self, request, pk=None):
         measurement = self.get_object()

--- a/bublik/interfaces/api_v2/measurements.py
+++ b/bublik/interfaces/api_v2/measurements.py
@@ -4,6 +4,7 @@
 from itertools import groupby
 import typing
 
+from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
@@ -37,7 +38,10 @@ class MeasurementViewSet(GenericViewSet):
     def by_result_ids(self, request):
         result_ids = request.data.get('result_ids', None)
         if not result_ids:
-            return Response({'error': 'No results ids specified'})
+            return Response(
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                data={'type': 'ValueError', 'message': 'No result IDs specified'},
+            )
 
         chart_views = get_chart_views(result_ids)
 

--- a/bublik/interfaces/api_v2/measurements.py
+++ b/bublik/interfaces/api_v2/measurements.py
@@ -11,8 +11,8 @@ from rest_framework.viewsets import GenericViewSet
 from bublik.core.measurement.representation import ChartViewBuilder
 from bublik.core.measurement.services import (
     get_chart_views,
-    get_lines_chart_views,
     get_points_chart_views,
+    get_y_chart_views,
     represent_measurements,
 )
 from bublik.data.models import Measurement
@@ -42,13 +42,15 @@ class MeasurementViewSet(GenericViewSet):
         chart_views = get_chart_views(result_ids)
 
         if chart_views:
-            chart_views_lines = get_lines_chart_views(chart_views)
+            chart_views_lines = get_y_chart_views(chart_views).filter(
+                view__metas__value='line-graph',
+            )
             chart_views_points = get_points_chart_views(chart_views)
 
             # Get charts from processing line graph chart views
             charts_from_lines = []
             for line_chart_view in chart_views_lines:
-                chart = ChartViewBuilder.by_line_graph(line_chart_view)
+                chart = ChartViewBuilder.by_lines(line_chart_view)
                 charts_from_lines.append(chart.representation())
 
             # Get charts from processing point chart views

--- a/bublik/interfaces/api_v2/measurements.py
+++ b/bublik/interfaces/api_v2/measurements.py
@@ -1,12 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
-import contextlib
-
 from itertools import groupby
 import typing
 
-from django.conf import settings
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
@@ -36,16 +33,9 @@ class MeasurementViewSet(GenericViewSet):
         serializer = self.get_serializer(Measurement.objects.filter(), many=True)
         return Response(serializer.data)
 
-    @action(detail=False, methods=['post', 'get'])
-    def by_results_ids(self, request):
-        results_ids = None
-        if request.method == 'GET':
-            with contextlib.suppress(AttributeError):
-                results_ids = request.query_params.get('results_ids').split(
-                    settings.QUERY_DELIMITER,
-                )
-        elif request.method == 'POST':
-            results_ids = request.data.get('results_ids')
+    @action(detail=False, methods=['post'])
+    def by_result_ids(self, request):
+        results_ids = request.data.get('results_ids', None)
         if not results_ids:
             return Response({'error': 'No results ids specified'})
 

--- a/bublik/interfaces/api_v2/report.py
+++ b/bublik/interfaces/api_v2/report.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
 
 from itertools import groupby
-import logging
 
 from django.forms.models import model_to_dict
 from rest_framework import status
@@ -26,9 +25,6 @@ from bublik.data.models import (
 )
 from bublik.data.models.result import ResultType
 from bublik.data.serializers import ConfigSerializer, TestIterationResultSerializer
-
-
-logger = logging.getLogger('')
 
 
 __all__ = [
@@ -108,7 +104,7 @@ class ReportViewSet(RetrieveModelMixin, GenericViewSet):
         result = self.get_object()
         main_pkg = result.root
 
-        ### Get record points and build axis names ###
+        ### Get report points and unprocessed iterations ###
 
         mmrs_run = MeasurementResult.objects.filter(
             result__test_run=main_pkg,
@@ -153,7 +149,7 @@ class ReportViewSet(RetrieveModelMixin, GenericViewSet):
 
         mmrs_report = mmrs_report.order_by('id')
 
-        # get points with data
+        # get points with data and unprocessed iterations
         points = []
         unprocessed_iters = []
         for mmr in mmrs_report:

--- a/bublik/interfaces/api_v2/report.py
+++ b/bublik/interfaces/api_v2/report.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
 
-from itertools import groupby
-
 from django.forms.models import model_to_dict
 from rest_framework import status
 from rest_framework.decorators import action
@@ -172,19 +170,14 @@ class ReportViewSet(RetrieveModelMixin, GenericViewSet):
 
         ### Group points into records ###
         content = []
-        points = sorted(points, key=ReportPoint.points_grouper_tests)
-        point_groups_by_test_name = dict(
-            [test_name, list(points_group)]
-            for test_name, points_group in groupby(points, ReportPoint.points_grouper_tests)
-        )
-
+        points_by_test_names = ReportPoint.grouper(points, 'test_name')
         if report_config['test_names_order']:
-            point_groups_by_test_name = ReportPoint.by_test_name_sort(
-                point_groups_by_test_name,
+            points_by_test_names = ReportPoint.by_test_name_sort(
+                points_by_test_names,
                 report_config['test_names_order'],
             )
 
-        for test_name, test_points in point_groups_by_test_name.items():
+        for test_name, test_points in points_by_test_names.items():
             test = ReportTestLevel(test_name, common_args, list(test_points), report_config)
             content.append(test.__dict__)
 

--- a/bublik/interfaces/api_v2/results.py
+++ b/bublik/interfaces/api_v2/results.py
@@ -276,7 +276,7 @@ class ResultViewSet(ModelViewSet):
             line_graph_views = get_line_graph_views(views)
             if line_graph_views:
                 for view in line_graph_views:
-                    line_chart_views = get_chart_views([pk], view)
+                    line_chart_views = get_chart_views(pk, view)
                     x_chart_view = get_x_chart_view(line_chart_views)
                     y_chart_views = get_y_chart_views(line_chart_views)
 
@@ -307,7 +307,7 @@ class ResultViewSet(ModelViewSet):
                     return cv.measurement.id
 
                 for view in point_views:
-                    point_chart_views = get_chart_views([pk], view)
+                    point_chart_views = get_chart_views(pk, view)
                     point_chart_views = sorted(point_chart_views, key=grouper_by_measurement)
                     for _measurement_id, points in groupby(
                         point_chart_views,

--- a/bublik/interfaces/management/commands/cleanup_db.py
+++ b/bublik/interfaces/management/commands/cleanup_db.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
+
+from django.contrib.postgres.aggregates import ArrayAgg
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.db.models import Count
+
+from bublik.data.models import (
+    ChartView,
+    MeasurementResult,
+    MeasurementResultList,
+    View,
+)
+
+
+class Command(BaseCommand):
+    def move_mmr_sequences(self):
+        '''
+        Find sequences among MeasurementResult objects and move them
+        to the MeasurementResultList.
+        '''
+        self.stdout.write('Move measurement result sequences:')
+
+        # get mmr values sequences
+        aggregated_data = (
+            MeasurementResult.objects.values('result', 'measurement')
+            .annotate(value_list=ArrayAgg('value', ordering='serial'), count=Count('id'))
+            .filter(count__gt=1)
+        )
+
+        # save the sequences as MeasurementResultList objects and
+        # delete the corresponding MeasurementResult objects
+        created_mmrl_count = 0
+        all_deleted_mmr_count = 0
+        for data in aggregated_data:
+            MeasurementResultList.objects.create(
+                result_id=data['result'],
+                measurement_id=data['measurement'],
+                value=data['value_list'],
+            )
+            created_mmrl_count += 1
+
+            deleted_mr_count, _ = MeasurementResult.objects.filter(
+                result_id=data['result'],
+                measurement_id=data['measurement'],
+            ).delete()
+            all_deleted_mmr_count += deleted_mr_count
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f'\tCREATED: {created_mmrl_count} MeasurementResultList objects',
+            ),
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f'\tDELETED: {all_deleted_mmr_count} MeasurementResult objects',
+            ),
+        )
+
+    def delete_incorrect_cv(self):
+        '''
+        Delete type X and Y ChartView objects linking unit measurements to line-graph
+        type views.
+        '''
+        self.stdout.write('Delete incorrect ChartView objects:')
+
+        all_incorrect = 0
+        remaining_mmr = MeasurementResult.objects.values('result', 'measurement').distinct()
+        for data in remaining_mmr:
+            incorrect, _ = (
+                ChartView.objects.exclude(type='P')
+                .filter(result_id=data['result'], measurement_id=data['measurement'])
+                .delete()
+            )
+            all_incorrect += incorrect
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f'\tDELETED: {all_incorrect} ChartView objects',
+            ),
+        )
+
+    def delete_duplicate_cv(self):
+        '''
+        Delete duplicate ChartView objects.
+        '''
+        self.stdout.write('Delete duplicate ChartView objects:')
+
+        duplicate = 0
+        with transaction.atomic():
+            unique_views_data = set()
+            for cv in ChartView.objects.all():
+                view_data = (cv.type, cv.measurement, cv.result, cv.view)
+                if view_data in unique_views_data:
+                    cv.delete()
+                    duplicate += 1
+                else:
+                    unique_views_data.add(view_data)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f'\tDELETED: {duplicate} ChartView objects',
+            ),
+        )
+
+    def delete_unused_views(self):
+        '''
+        Delete View objects that are not referenced by any ChartView object.
+        '''
+        self.stdout.write('Delete unused View objects:')
+
+        unused, _ = View.objects.exclude(
+            id__in=ChartView.objects.values('view_id'),
+        ).delete()
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f'\tDELETED: {unused} View objects',
+            ),
+        )
+
+    def handle(self, *args, **options):
+        self.move_mmr_sequences()
+        self.delete_incorrect_cv()
+        self.delete_duplicate_cv()
+        self.delete_unused_views()


### PR DESCRIPTION
## Overview

### Importruns
1. Fixed duplication of `ChartView` objects during forced import.
2. Fixed creation of `ChartView` objects that are not linked to measurements.
3. Fixed creation of `ChartView` objects of types that do not correspond to the measurements. Now `X` and `Y` type `ChartView` objects are created only for measurements whose results are sequences, and `P` type `ChartView` objects are created only for measurements whose results are singles (for example, aggregations).
4. The sequences of measurement results (entries that differ from each other only in value) are saved as a list in a separate table (see `MeasurementResultList` below).

### Reports
1. Fixed measurement chart labels.
2. Simplified grouping of points.
3. A little cleaning and refactoring has been done.

### Models
`MeasurementResultList` model has been created. It has the same structure as `MeasurementResult` model (`id`, `value`, `serial`, `measurement`, `result` fields), except that the value field is an array field.

### Serializers

1. `MeasurementResultListSerializer` — `MeasurementResultList` model serializer.
6. `MeasurementResultCommonSerializer` — the parent serializer for `MeasurementResultSerializer` and `MeasurementResultListSerializer.` Created to extend to `MeasurementResultListSerializer` the methods defined for `MeasurementResultSerializer`.

### API

> **Note**
> The endpoint for obtaining data for plotting has been changed, as well as the data format.

#### 1. /api/v2/results/\<result ID>/measurements/

Allows you to get data for plotting charts and measurement tables for a single iteration.
Allowed methods: GET
Response data:

```
{
    "run_id": 8001,
    "iteration_id": 7985,
    "charts": [
        {
            "id": 24,
            "title": null,
            "subtitle": "Throughput (Mbps, single): based on Statistics",
            "axis_x": {
                "label": "Sequence number",
                "key": "Sequence number"
            },
            "axis_y": {
                "label": "Output (Mbps)",
                "key": "Output (Mbps)"
            },
            "dataset": [
                [
                    "Sequence number",
                    "Output (Mbps)"
                ],
                [
                    0,
                    106.74
                ],
                [
                    1,
                    497.59
                ],
                [
                    2,
                    654.68
                ],
                [
                    3,
                    376.92
                ],
                [
                    4,
                    237.27
                ],
                [
                    5,
                    230.56
                ],
                [
                    6,
                    728.16
                ],
                [
                    7,
                    712.44
                ],
                [
                    8,
                    987.58
                ],
                [
                    9,
                    165.74
                ],
                [
                    10,
                    714.27
                ],
                [
                    11,
                    724.17
                ],
                [
                    12,
                    723.94
                ]
            ]
        },
        {
            "id": 29,
            "title": null,
            "subtitle": "Throughput (Mbps, single): based on Statistics",
            "axis_x": {
                "label": "Time (second)",
                "key": "Time (second)"
            },
            "axis_y": {
                "label": "Input (Mbps)",
                "key": "Input (Mbps)"
            },
            "dataset": [
                [
                    "Time (second)",
                    "Input (Mbps)"
                ],
                [
                    7.1,
                    263.92
                ],
                [
                    3.7,
                    504.61
                ],
                [
                    8.2,
                    701.56
                ],
                [
                    4.9,
                    745.53
                ],
                [
                    9.4,
                    650.9
                ],
                [
                    8.8,
                    750.78
                ],
                [
                    10.2,
                    728.7
                ],
                [
                    9.9,
                    726.0
                ],
                [
                    11.3,
                    722.92
                ],
                [
                    10.8,
                    715.78
                ],
                [
                    12.0,
                    768.33
                ]
            ]
        }
    ],
    "tables": [
        {
            "measurement_id": 17,
            "type": "connections",
            "name": "Connections (average)",
            "tool": "TR",
            "aggr": "single",
            "units": "cps",
            "keys": [],
            "comments": [],
            "value": 834.414
        },
        {
            "measurement_id": 18,
            "type": "connections",
            "name": "Connections (expected)",
            "tool": "TR",
            "aggr": "single",
            "units": "cps",
            "keys": [],
            "comments": [],
            "value": 1000.0
        }
    ]
}
```

Response status code: 200

#### 2. /api/v2/measurements/by\_result\_ids/

Allows you to get data for plotting dynamics based on the results of iterations.
Allowed methods: POST
POST request data:

```
{
    "result_ids": <list of result IDS>
}
```

Possible cases and responses:
1. There are no result IDs in the request
Response data:
```
{
    "type": "ValueError",
    "message": "No result IDs specified"
}
```
Response status code: 422

2. There are result IDs in the request
Response data:
```
[
    {
        "id": 4,
        "title": null,
        "subtitle": "Bandwidth-usage (mean): based on testpmd  (Side=Tx)",
        "axis_x": {
            "label": "Start of measurement test",
            "key": "start"
        },
        "axis_y": {
            "label": "bandwidth-usage",
            "key": "value"
        },
        "dataset": [
            [
                "start",
                "value",
                "run_id",
                "result_id",
                "iteration_id",
                "measurement_id",
                "comments"
            ],
            [
                "2024-10-18T04:16:14.473000Z",
                1.0,
                1,
                7680,
                7659,
                4,
                [
                    "Stabilizaton=reached on datapoint (+ leading zero datapoints): 10 (+ 1)"
                ]
            ],
            [
                "2024-10-18T04:16:33.180000Z",
                1.0,
                1,
                7681,
                7660,
                4,
                [
                    "Stabilizaton=reached on datapoint (+ leading zero datapoints): 10 (+ 1)"
                ]
            ],
            [
                "2024-10-18T04:16:51.690000Z",
                1.0,
                1,
                7682,
                7661,
                4,
                [
                    "Stabilizaton=reached on datapoint (+ leading zero datapoints): 10 (+ 1)"
                ]
            ]
        ]
    },
    {
        "id": 1,
        "title": null,
        "subtitle": "Pps (cv): based on testpmd  (Side=Tx)",
        "axis_x": {
            "label": "Start of measurement test",
            "key": "start"
        },
        "axis_y": {
            "label": "pps",
            "key": "value"
        },
        "dataset": [
            [
                "start",
                "value",
                "run_id",
                "result_id",
                "iteration_id",
                "measurement_id",
                "comments"
            ],
            [
                "2024-10-18T04:16:14.473000Z",
                3.40957e-07,
                1,
                7680,
                7659,
                1,
                [
                    "Stabilizaton=reached on datapoint (+ leading zero datapoints): 10 (+ 1)"
                ]
            ],
            [
                "2024-10-18T04:16:33.180000Z",
                3.01371e-07,
                1,
                7681,
                7660,
                1,
                [
                    "Stabilizaton=reached on datapoint (+ leading zero datapoints): 10 (+ 1)"
                ]
            ],
            [
                "2024-10-18T04:16:51.690000Z",
                1.92479e-07,
                1,
                7682,
                7661,
                1,
                [
                    "Stabilizaton=reached on datapoint (+ leading zero datapoints): 10 (+ 1)"
                ]
            ]
        ]
    },
    {
        "id": 2,
        "title": null,
        "subtitle": "Pps (pps, mean): based on testpmd  (Side=Tx)",
        "axis_x": {
            "label": "Start of measurement test",
            "key": "start"
        },
        "axis_y": {
            "label": "pps (pps)",
            "key": "value"
        },
        "dataset": [
            [
                "start",
                "value",
                "run_id",
                "result_id",
                "iteration_id",
                "measurement_id",
                "comments"
            ],
            [
                "2024-10-18T04:16:14.473000Z",
                14881000.0,
                1,
                7680,
                7659,
                2,
                [
                    "Stabilizaton=reached on datapoint (+ leading zero datapoints): 10 (+ 1)"
                ]
            ],
            [
                "2024-10-18T04:16:33.180000Z",
                14881000.0,
                1,
                7681,
                7660,
                2,
                [
                    "Stabilizaton=reached on datapoint (+ leading zero datapoints): 10 (+ 1)"
                ]
            ],
            [
                "2024-10-18T04:16:51.690000Z",
                14881000.0,
                1,
                7682,
                7661,
                2,
                [
                    "Stabilizaton=reached on datapoint (+ leading zero datapoints): 10 (+ 1)"
                ]
            ]
        ]
    },
    {
        "id": 3,
        "title": null,
        "subtitle": "Throughput (Mbps, mean): based on testpmd  (Side=Tx)",
        "axis_x": {
            "label": "Start of measurement test",
            "key": "start"
        },
        "axis_y": {
            "label": "throughput (Mbps)",
            "key": "value"
        },
        "dataset": [
            [
                "start",
                "value",
                "run_id",
                "result_id",
                "iteration_id",
                "measurement_id",
                "comments"
            ],
            [
                "2024-10-18T04:16:14.473000Z",
                10000.0,
                1,
                7680,
                7659,
                3,
                [
                    "Stabilizaton=reached on datapoint (+ leading zero datapoints): 10 (+ 1)"
                ]
            ],
            [
                "2024-10-18T04:16:33.180000Z",
                10000.0,
                1,
                7681,
                7660,
                3,
                [
                    "Stabilizaton=reached on datapoint (+ leading zero datapoints): 10 (+ 1)"
                ]
            ],
            [
                "2024-10-18T04:16:51.690000Z",
                10000.0,
                1,
                7682,
                7661,
                3,
                [
                    "Stabilizaton=reached on datapoint (+ leading zero datapoints): 10 (+ 1)"
                ]
            ]
        ]
    }
]
```
Response status code: 200

#### 3. /api/v2/report/<run ID\>/?config=<config ID\>

Allows you to get data for report building.
Allowed methods: GET
Response data:
```
{
    "warnings": [],
    "config": {
        "name": "DPDK",
        "version": 1,
        "description": "DPDK Performance Report"
    },
    "content": [
        {
            "type": "test-block",
            "id": "testpmd_txonly",
            "label": "testpmd_txonly",
            "enable_table_view": true,
            "enable_chart_view": true,
            "common_args": {
                "env": "VAR.env.perf.peer2peer",
                "testpmd_arg_forward_mode": "txonly",
                "testpmd_arg_no_lsc_interrupt": "TRUE",
            },
            "content": [
                {
                    "type": "arg-val-block",
                    "args_vals": {
                        "cores": 1,
                        "arg_burst": 32,
                    },
                    "label": "cores: 1 | arg_burst: 32",
                    "id": "testpmd_txonly_cores:1|arg_burst:32",
                    "content": [
                        {
                            "type": "measurement-block",
                            "label": "Pps (pps, mean): based on testpmd (Side=Tx)",
                            "id": "testpmd_txonly_cores:1|arg_burst:32_41",
                            "content": [
                                {
                                    "type": "record-block",
                                    "id": "testpmd_txonly_cores:1|arg_burst:32_41_41",
                                    "label": "pps (pps)",
                                    "chart": {
                                        "warnings": [
                                            "The results corresponding to txpkts=42,1472 cannot be displayed on the chart"
                                        ],
                                        "axis_x": {
                                            "label": "txpkts",
                                            "key": "x_value",
                                            "values": [
                                                42,
                                                252,
                                                2044,
                                            ]
                                        },
                                        "axis_y": {
                                            "label": "pps (pps)",
                                            "key": "y_value"
                                        },
                                        "series_label": null,
                                        "data": [
                                            {
                                                "series": "None",
                                                "points": [
                                                    {
                                                        "x_value": 42,
                                                        "y_value": 14881000.0,
                                                        "metadata": {
                                                            "iteration_id": 7799,
                                                            "result_id": 33276
                                                        }
                                                    },
                                                    {
                                                        "x_value": 252,
                                                        "y_value": 4529000.0,
                                                        "metadata": {
                                                            "iteration_id": 7823,
                                                            "result_id": 33468
                                                        }
                                                    },
                                                    {
                                                        "x_value": 2044,
                                                        "y_value": 604449.0,
                                                        "metadata": {
                                                            "iteration_id": 7863,
                                                            "result_id": 33788
                                                        }
                                                    }
                                                ]
                                            }
                                        ]
                                    },
                                    "table": {
                                        "warnings": [],
                                        "formatters": {},
                                        "labels": {
                                            "x_value": "txpkts",
                                            "y_value": "pps (pps)",
                                            "series": null
                                        },
                                        "data": [
                                            {
                                                "series": "None",
                                                "points": [
                                                    {
                                                        "x_value": 42,
                                                        "y_value": 14881000.0,
                                                        "metadata": {
                                                            "iteration_id": 7799,
                                                            "result_id": 33276
                                                        }
                                                    },
                                                    {
                                                        "x_value": 252,
                                                        "y_value": 4529000.0,
                                                        "metadata": {
                                                            "iteration_id": 7823,
                                                            "result_id": 33468
                                                        }
                                                    },
                                                    {
                                                        "x_value": "42,1472",
                                                        "y_value": 812745.0,
                                                        "metadata": {
                                                            "iteration_id": 7855,
                                                            "result_id": 33724
                                                        }
                                                    },
                                                    {
                                                        "x_value": 2044,
                                                        "y_value": 604449.0,
                                                        "metadata": {
                                                            "iteration_id": 7863,
                                                            "result_id": 33788
                                                        }
                                                    }
                                                ]
                                            }
                                        ]
                                    }
                                }
                            ]
                        }
                    ]
                }
            ]
        }
    ]
}
```