### PR TITLE
Settings, auth: update the source of the main configuration

### DIFF
--- a/bublik/core/auth.py
+++ b/bublik/core/auth.py
@@ -3,15 +3,13 @@
 
 from functools import wraps
 
-import per_conf
-
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework_simplejwt.backends import TokenBackend
 from rest_framework_simplejwt.exceptions import TokenBackendError
 
-from bublik.data.models import User, UserRoles
+from bublik.data.models import Config, ConfigTypes, GlobalConfigNames, User, UserRoles
 from bublik.settings import SIMPLE_JWT
 
 
@@ -85,8 +83,12 @@ def check_action_permission(action):
     def wrapper(func):
         @wraps(func)
         def inner(*args, **kwargs):
-            not_permission_required_actions = getattr(
-                per_conf,
+            per_conf = Config.objects.get(
+                type=ConfigTypes.GLOBAL,
+                name=GlobalConfigNames.PER_CONF,
+                is_active=True,
+            )
+            not_permission_required_actions = per_conf.content.get(
                 'NOT_PERMISSION_REQUIRED_ACTIONS',
                 [],
             )

--- a/bublik/interfaces/main_api/redirects.py
+++ b/bublik/interfaces/main_api/redirects.py
@@ -51,7 +51,7 @@ def redirect_result_log(request, result_id):
 
 
 def redirect_next(request):
-    new_path = request.path.replace('next', settings.URL_PREFIX_BY_UI_VERSION[2])
+    new_path = request.path.replace('next', settings.UI_PREFIX)
     return redirect(new_path)
 
 

--- a/bublik/interfaces/management/commands/reformat_configs.py
+++ b/bublik/interfaces/management/commands/reformat_configs.py
@@ -9,122 +9,18 @@ from bublik.data.models import Config, ConfigTypes, GlobalConfigNames
 from bublik.data.serializers import ConfigSerializer
 
 
+def update_config_content(config_instance, new_content):
+    serializer = ConfigSerializer(
+        instance=config_instance,
+        data={'content': new_content},
+        partial=True,
+    )
+    serializer.is_valid(raise_exception=True)
+    config_instance.content = serializer.validated_data['content']
+    config_instance.save()
+
+
 class Command(BaseCommand):
-    def update_axis_x_structure(self, configs):
-        '''
-        Reformat passed report configs content:
-        "axis_x": <str> -> "axis_x": {"arg": <str>}
-        '''
-        report_configs = configs.filter(type=ConfigTypes.REPORT)
-        for report_config in report_configs:
-            try:
-                config_data = report_config.content
-                modified = False
-                for test_name, test_config_data in config_data['tests'].items():
-                    if isinstance(test_config_data['axis_x'], str):
-                        modified = True
-                        test_config_data['axis_x'] = {
-                            'arg': test_config_data['axis_x'],
-                        }
-                        config_data['tests'][test_name] = test_config_data
-
-                if modified:
-                    serializer = ConfigSerializer(
-                        instance=report_config,
-                        data={'content': config_data},
-                        partial=True,
-                    )
-                    serializer.is_valid(raise_exception=True)
-                    report_config.content = serializer.validated_data['content']
-                    report_config.save()
-
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            f'{report_config.name} v{report_config.version}: '
-                            'the x-axis settings structure has been successfully updated!',
-                        ),
-                    )
-                else:
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            f'{report_config.name} v{report_config.version}: '
-                            'the x-axis settings structure already updated!',
-                        ),
-                    )
-            except Exception as e:
-                self.stdout.write(
-                    self.style.ERROR(
-                        f'{report_config.name} v{report_config.version}: '
-                        f'failed to update x-axis settings structure: {type(e).__name__}: {e}',
-                    ),
-                )
-
-    def update_seq_settings_structure(self, configs):
-        '''
-        Reformat passed report configs content:
-        Add the 'sequences' foreign key for all sequences settings
-        (sequence_group_arg, percentage_base_value, sequence_name_conversion).
-        Rename 'sequence_name_conversion' to 'arg_vals_labels'.
-        '''
-        report_configs = configs.filter(type=ConfigTypes.REPORT)
-        for report_config in report_configs:
-            try:
-                config_data = report_config.content
-                modified = False
-                for test_name, test_config_data in config_data['tests'].items():
-                    if 'sequences' not in test_config_data:
-                        modified = True
-                        if test_config_data['sequence_group_arg'] is not None:
-                            test_config_data['sequences'] = {
-                                'arg': test_config_data['sequence_group_arg'],
-                            }
-                            if test_config_data['percentage_base_value'] is not None:
-                                test_config_data['sequences'][
-                                    'percentage_base_value'
-                                ] = test_config_data['percentage_base_value']
-                            if test_config_data['sequence_name_conversion']:
-                                test_config_data['sequences'][
-                                    'arg_vals_labels'
-                                ] = test_config_data['sequence_name_conversion']
-
-                        test_config_data.pop('sequence_group_arg')
-                        test_config_data.pop('percentage_base_value')
-                        test_config_data.pop('sequence_name_conversion')
-
-                        config_data['tests'][test_name] = test_config_data
-
-                if modified:
-                    serializer = ConfigSerializer(
-                        instance=report_config,
-                        data={'content': config_data},
-                        partial=True,
-                    )
-                    serializer.is_valid(raise_exception=True)
-                    report_config.content = serializer.validated_data['content']
-                    report_config.save()
-
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            f'{report_config.name} v{report_config.version}: '
-                            'the sequences settings structure has been successfully updated!',
-                        ),
-                    )
-                else:
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            f'{report_config.name} v{report_config.version}: '
-                            'the sequences settings structure already updated!',
-                        ),
-                    )
-            except Exception as e:
-                self.stdout.write(
-                    self.style.ERROR(
-                        f'{report_config.name} v{report_config.version}: '
-                        'failed to update sequences settings structure: '
-                        f'{type(e).__name__}: {e}',
-                    ),
-                )
-
     def get_configs(self, options):
         '''
         Get a list of configurations filtered by the passed types and names.
@@ -167,6 +63,105 @@ class Command(BaseCommand):
 
         return None
 
+    def update_axis_x_structure(self, configs):
+        '''
+        Reformat passed report configs content:
+        "axis_x": <str> -> "axis_x": {"arg": <str>}
+        '''
+        report_configs = configs.filter(type=ConfigTypes.REPORT)
+        for report_config in report_configs:
+            try:
+                config_data = report_config.content
+                modified = False
+                for test_name, test_config_data in config_data['tests'].items():
+                    if isinstance(test_config_data['axis_x'], str):
+                        modified = True
+                        test_config_data['axis_x'] = {
+                            'arg': test_config_data['axis_x'],
+                        }
+                        config_data['tests'][test_name] = test_config_data
+
+                if modified:
+                    update_config_content(report_config, config_data)
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f'{report_config.name} v{report_config.version}: '
+                            'the x-axis settings structure has been successfully updated!',
+                        ),
+                    )
+                else:
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f'{report_config.name} v{report_config.version}: '
+                            'the x-axis settings structure already updated!',
+                        ),
+                    )
+            except Exception as e:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f'{report_config.name} v{report_config.version}: '
+                        f'failed to update x-axis settings structure: {type(e).__name__}: {e}',
+                    ),
+                )
+
+    def update_seq_settings_structure(self, configs):
+        '''
+        Reformat passed report configs content:
+        Add the 'sequences' foreign key for all sequences settings
+        (sequence_group_arg, percentage_base_value, sequence_name_conversion).
+        Rename 'sequence_name_conversion' to 'arg_vals_labels'.
+        '''
+        report_configs = configs.filter(type=ConfigTypes.REPORT)
+        for report_config in report_configs:
+            try:
+                config_data = report_config.content
+                modified = False
+                for test_name, test_config_data in config_data['tests'].items():
+                    if 'sequences' not in test_config_data:
+                        modified = True
+                        if test_config_data['sequence_group_arg'] is not None:
+                            test_config_data['sequences'] = {
+                                'arg': test_config_data['sequence_group_arg'],
+                            }
+                            if test_config_data['percentage_base_value'] is not None:
+                                test_config_data['sequences']['percentage_base_value'] = (
+                                    test_config_data['percentage_base_value']
+                                )
+                            if test_config_data['sequence_name_conversion']:
+                                test_config_data['sequences']['arg_vals_labels'] = (
+                                    test_config_data['sequence_name_conversion']
+                                )
+
+                        test_config_data.pop('sequence_group_arg')
+                        test_config_data.pop('percentage_base_value')
+                        test_config_data.pop('sequence_name_conversion')
+
+                        config_data['tests'][test_name] = test_config_data
+
+                if modified:
+                    update_config_content(report_config, config_data)
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f'{report_config.name} v{report_config.version}: '
+                            'the sequences settings structure has been successfully updated!',
+                        ),
+                    )
+                else:
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f'{report_config.name} v{report_config.version}: '
+                            'the sequences settings structure already updated!',
+                        ),
+                    )
+            except Exception as e:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f'{report_config.name} v{report_config.version}: '
+                        'failed to update sequences settings structure: '
+                        f'{type(e).__name__}: {e}',
+                    ),
+                )
+
     def update_dashboard_header_structure(self, configs):
         '''
         Reformat passed global per_conf configs content:
@@ -185,16 +180,7 @@ class Command(BaseCommand):
                         {'key': key, 'label': label}
                         for key, label in config_data['DASHBOARD_HEADER'].items()
                     ]
-
-                    serializer = ConfigSerializer(
-                        instance=per_conf_config,
-                        data={'content': config_data},
-                        partial=True,
-                    )
-                    serializer.is_valid(raise_exception=True)
-                    per_conf_config.content = serializer.validated_data['content']
-                    per_conf_config.save()
-
+                    update_config_content(per_conf_config, config_data)
                     self.stdout.write(
                         self.style.SUCCESS(
                             f'{per_conf_config.name} v{per_conf_config.version}: '

--- a/bublik/middleware.py
+++ b/bublik/middleware.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
+
+from django.conf import settings
+from django.core.cache import caches
+from django.core.exceptions import ObjectDoesNotExist
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from bublik.data.models import Config, ConfigTypes, GlobalConfigNames
+
+
+@receiver(post_save, sender=Config)
+def invalidate_config_cache(sender, instance, **kwargs):
+    if (
+        instance.type == ConfigTypes.GLOBAL
+        and instance.name == GlobalConfigNames.PER_CONF
+        and instance.is_active
+    ):
+        caches['config'].delete('content')
+
+
+def get_config_from_cache(default=None):
+    config = caches['config'].get('content')
+    if config is None:
+        try:
+            config = Config.objects.get(
+                type=ConfigTypes.GLOBAL,
+                name=GlobalConfigNames.PER_CONF,
+                is_active=True,
+            ).content
+            caches['config'].set('content', config, timeout=86400)
+        except ObjectDoesNotExist:
+            config = default
+    return config
+
+
+class DynamicSettingsMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        config = get_config_from_cache()
+
+        # set CSRF_TRUSTED_ORIGINS
+        csrf_trusted_origins = config.get('CSRF_TRUSTED_ORIGINS', [])
+        settings.CSRF_TRUSTED_ORIGINS = csrf_trusted_origins
+
+        # set UI_PREFIX
+        ui_version = config.get('UI_VERSION', 2)
+        ui_prefix_by_ui_version = {
+            2: 'v2',
+        }
+        ui_prefix = ui_prefix_by_ui_version.get(ui_version, '')
+        settings.UI_PREFIX = ui_prefix
+
+        return self.get_response(request)

--- a/templates/settings.py.template
+++ b/templates/settings.py.template
@@ -70,6 +70,7 @@ if not DEBUG:
     INSTALLED_APPS.append('cachalot')
 
 MIDDLEWARE = [
+    'bublik.middleware.DynamicSettingsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.cache.UpdateCacheMiddleware',
@@ -202,6 +203,11 @@ CACHES = {
                 'compresslevel': 9,
             },
         }
+    },
+    'config': {
+        'BACKEND': 'redis_cache.RedisCache',
+        'LOCATION': '127.0.0.1:6379',
+        'TIMEOUT': 86400,
     }
 }
 
@@ -311,16 +317,6 @@ get_module('per_conf', '${PER_CONF_DIR}/per_conf.py')
 get_module('references', '${PER_CONF_DIR}/references.py')
 
 import per_conf
-
-URL_PREFIX_BY_UI_VERSION = {
-    2: 'v2',
-}
-
-UI_VERSION = getattr(per_conf, 'UI_VERSION', 2)
-
-UI_PREFIX = URL_PREFIX_BY_UI_VERSION.get(UI_VERSION, '')
-
-CSRF_TRUSTED_ORIGINS = getattr(per_conf, 'CSRF_TRUSTED_ORIGINS', [])
 
 ITEMS_PER_PAGE = 25
 


### PR DESCRIPTION
1. Create a middleware to get the values of Django dynamic settings from the active main configuration from the database, and not from the *per_conf.py*. Fix this in auth as well.
2. Add step to reformat the main configuration to ensure all `CSRF_TRUSTED_ORIGINS` use HTTP/HTTPS schemes if missing, as required by Django 4.0+.