### PR TITLE
Importruns: fix log parsing

### DIFF
--- a/scripts/xml_log_parser
+++ b/scripts/xml_log_parser
@@ -307,21 +307,21 @@ sub handle_end
 
     if ($e eq "start-ts")
     {
-        $cur_iter->{start_ts} = fix_start($p->{start_ts});
-        if ($first_ts eq '')
-        {
-            $first_ts = $cur_iter->{start_ts};
-        }
+        $cur_iter->{start_ts} = $p->{start_ts};
     }
     elsif ($e eq "end-ts")
     {
         $cur_iter->{end_ts} = $p->{end_ts};
-        $last_ts = $cur_iter->{end_ts};
     }
     elsif ($e eq "duration")
     {
-        $cur_iter->{end_ts} = fix_end($p->{start_ts}, $cur_iter->{end_ts}, $p->{duration});
+        $cur_iter->{end_ts} = fix_end($cur_iter->{start_ts}, $cur_iter->{end_ts}, $p->{duration});
         $last_ts = $cur_iter->{end_ts};
+        $cur_iter->{start_ts} = fix_start($cur_iter->{start_ts});
+        if ($first_ts eq '')
+        {
+            $first_ts = $cur_iter->{start_ts};
+        }
     }
     elsif ($e eq "objective")
     {

--- a/scripts/xml_log_parser
+++ b/scripts/xml_log_parser
@@ -221,9 +221,14 @@ sub get_unix_date
         my $time_in_sec = $1 * 60 * 60 + $2 * 60 + $3;
         my $day_in_sec = 24 * 60 * 60;
 
+        # update the UNIX date according to the time
+        my $day_start = $base_tv - ($base_tv % $day_in_sec);
+        $unix_date = $day_start + $time_in_sec;
+
+        # add 1 day to the UNIX date if the time is less than the base time
         if ($base_tv % $day_in_sec > $time_in_sec)
         {
-            $unix_date = $base_tv + $day_in_sec;
+            $unix_date += $day_in_sec;
         }
     }
 


### PR DESCRIPTION
Fix the calculation of the start and end dates of the iteration when parsing logs.