### PR TITLE
Management: fix mmr sequences migration

### DIFF
--- a/bublik/interfaces/management/commands/cleanup_db.py
+++ b/bublik/interfaces/management/commands/cleanup_db.py
@@ -39,7 +39,10 @@ class Command(BaseCommand):
                 )
                 for ad in aggregated_data
             ]
-            created_mmrl = MeasurementResultList.objects.bulk_create(mmr_lists)
+            created_mmrl = MeasurementResultList.objects.bulk_create(
+                mmr_lists,
+                batch_size=1000,
+            )
 
             # delete the corresponding MeasurementResult objects
             deleted_mmr_count, _ = MeasurementResult.objects.filter(


### PR DESCRIPTION
Use batch_size in bulk_create() to split the operation into smaller batches and prevent issues with large inserts.