### PR TITLE
Settings: enhance email configuration flexibility

### DIFF
--- a/bublik/data/schemas/per_conf.json
+++ b/bublik/data/schemas/per_conf.json
@@ -184,6 +184,34 @@
                 "type": "string"
             },
             "uniqueItems": true
+        },
+        "EMAIL_PORT": {
+            "description": "Defines the port to be used for the email server connection (25 by default)",
+            "type": "number"
+        },
+        "EMAIL_HOST": {
+            "description": "The SMTP server to be used for sending emails (localhost by default)",
+            "type": "string"
+        },
+        "EMAIL_USE_TLS": {
+            "description": "A boolean setting that specifies whether to use TLS for email communication (True by default)",
+            "type": "boolean"
+        },
+        "EMAIL_TIMEOUT": {
+            "description": "Sets the timeout (in seconds) for email sending operations (60 by default)",
+            "type": "number"
+        },
+        "EMAIL_FROM": {
+            "description": "The default \"from\" address for sending emails (noreply@ts-factory.io by default)",
+            "type": "string"
+        },
+        "EMAIL_ADMINS": {
+            "description": "A list of email addresses to which error notifications should be sent ([\"bublik@ts-factory.io\"] by default)",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
         }
     },
     "required": [

--- a/bublik/middleware.py
+++ b/bublik/middleware.py
@@ -54,4 +54,12 @@ class DynamicSettingsMiddleware:
         ui_prefix = ui_prefix_by_ui_version.get(ui_version, '')
         settings.UI_PREFIX = ui_prefix
 
+        # set email settings
+        settings.EMAIL_PORT = config.get('EMAIL_PORT', 25)
+        settings.EMAIL_HOST = config.get('EMAIL_HOST', 'localhost')
+        settings.EMAIL_USE_TLS = config.get('EMAIL_USE_TLS', True)
+        settings.EMAIL_TIMEOUT = config.get('EMAIL_TIMEOUT', 60)
+        settings.EMAIL_FROM = config.get('EMAIL_FROM', 'noreply@ts-factory.io')
+        settings.EMAIL_ADMINS = config.get('EMAIL_ADMINS', ['bublik@ts-factory.io'])
+
         return self.get_response(request)

--- a/templates/settings.py.template
+++ b/templates/settings.py.template
@@ -360,13 +360,7 @@ PERIOD_DELIMITER = '-'
 TIMESTAMP_DELIMITER = 's'
 
 # Email settings
-EMAIL_HOST = 'localhost'
-EMAIL_PORT = 25
-EMAIL_USE_TLS = True
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_TIMEOUT = 60
-EMAIL_FROM = 'noreply@ts-factory.io'
-EMAIL_ADMINS = ['bublik@ts-factory.io']
 
 # Repo revisions
 REPO_REVISIONS = {


### PR DESCRIPTION
Increase the flexibility of the email configuration by allowing the specification and modification of the EMAIL_PORT, EMAIL_HOST, EMAIL_USE_TLS, EMAIL_TIMEOUT, EMAIL_FROM, and EMAIL_ADMINS settings in the project configuration.

Issue: #116