### PR TITLE
Importruns: fix measurement results processing

### DIFF
--- a/bublik/data/serializers/measurement.py
+++ b/bublik/data/serializers/measurement.py
@@ -59,9 +59,10 @@ class MeasurementResultCommonSerializer(ModelSerializer):
     def get_or_create(self):
         model = self.Meta.model
         value = self.validated_data.pop('value')
+        serial = self.validated_data.pop('serial')
         mmr, created = model.objects.get_or_create(
             **self.validated_data,
-            defaults={'value': value},
+            defaults={'value': value, 'serial': serial},
         )
         if created:
             return mmr, created


### PR DESCRIPTION
As a result of changes in the measurement results processing mechanism, the order of processing entries was modified, which in turn affects the serial number assigned to the measurement result. Therefore, during forced import, the same results may have different serial numbers and be treated as distinct, leading to object duplication. To prevent this, the serial number must be excluded from the check for measurement result existence in the database. This is correct because measurement result series are now stored as separate objects, and seriality of MeasurementResult objects is no longer supported.

Issue: #109