### PR TITLE
Report: enhance point metadata with result type

### DIFF
--- a/bublik/core/report/components.py
+++ b/bublik/core/report/components.py
@@ -81,6 +81,7 @@ class ReportPoint:
                 'metadata': {
                     'iteration_id': mmr.result.iteration.id,
                     'result_id': mmr.result.id,
+                    'result_type': mmr.result.meta_results.get(meta__type='result').meta.value,
                 },
             },
         }


### PR DESCRIPTION
Include the result type in each point's metadata to allow its representation in the report.

Issue: #108