### PR TITLE
References: fix default value for issues

### DIFF
--- a/bublik/core/run/compromised.py
+++ b/bublik/core/run/compromised.py
@@ -54,6 +54,7 @@ def validate_compromised_request(run_id, comment, bug, reference):
     if reference and reference not in ConfigServices.getattr_from_global(
         GlobalConfigNames.REFERENCES,
         'ISSUES',
+        default={},
     ):
         return f'Unknown reference key: {reference}.'
 
@@ -71,6 +72,7 @@ def mark_run_compromised(run_id, comment, bug_id, reference_key):
         ref_source = ConfigServices.getattr_from_global(
             GlobalConfigNames.REFERENCES,
             'ISSUES',
+            default={},
         )[reference_key]
         reference_data = {'name': ref_source['name'], 'uri': ref_source['uri'][0]}
 

--- a/bublik/core/run/keys.py
+++ b/bublik/core/run/keys.py
@@ -17,6 +17,7 @@ def prepare_expected_key(key_str):
         if ref_type not in ConfigServices.getattr_from_global(
             GlobalConfigNames.REFERENCES,
             'ISSUES',
+            default={},
         ):
             logger.warning(f"{key_str}: '{ref_type}' doesn`t match the project references")
 

--- a/bublik/core/run/stats.py
+++ b/bublik/core/run/stats.py
@@ -525,6 +525,7 @@ def get_expected_results(result):
                 logs = ConfigServices.getattr_from_global(
                     GlobalConfigNames.REFERENCES,
                     'ISSUES',
+                    default={},
                 )
                 if ref_type in logs and ref_tail:
                     ref_uri = logs[ref_type]['uri'][0]

--- a/bublik/interfaces/api_v2/outside_domains.py
+++ b/bublik/interfaces/api_v2/outside_domains.py
@@ -30,6 +30,7 @@ class OutsideDomainsViewSet(RetrieveModelMixin, GenericViewSet):
                 'issues': ConfigServices.getattr_from_global(
                     GlobalConfigNames.REFERENCES,
                     'ISSUES',
+                    default={},
                 ),
                 'revisions': ConfigServices.getattr_from_global(
                     GlobalConfigNames.REFERENCES,
@@ -56,6 +57,7 @@ class OutsideDomainsViewSet(RetrieveModelMixin, GenericViewSet):
                 'issues': ConfigServices.getattr_from_global(
                     GlobalConfigNames.REFERENCES,
                     'ISSUES',
+                    default={},
                 ),
             },
         )


### PR DESCRIPTION
The default value for issues should be an empty dictionary, as using None would result in an error when attempting to iterate.