### PR TITLE
Run stats: add filtering by requirements and retrieving a list of all run requirements

### DIFF
--- a/bublik/core/cache.py
+++ b/bublik/core/cache.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
 import functools
+from typing import ClassVar
 
 from django.core.cache import caches
 from django.core.exceptions import ObjectDoesNotExist
@@ -29,15 +30,15 @@ class RunCache:
             cache.data = produce_stats()
     """
 
-    KEY_DATA_CHOICES = {
+    KEY_DATA_CHOICES: ClassVar[set] = {
         'stats',
         'stats_sum',
         'dashboard-v2',
         'livelog',
         'tree',
     }
-    KEYS_EARLY_CACHE = {'livelog'}
-    KEYS_TMP_CACHE = {'tree'}
+    KEYS_EARLY_CACHE: ClassVar[set] = {'livelog'}
+    KEYS_TMP_CACHE: ClassVar[set] = {'tree'}
 
     def __init__(self, run, data_key):
         self.run = run

--- a/bublik/core/cache.py
+++ b/bublik/core/cache.py
@@ -33,6 +33,7 @@ class RunCache:
     KEY_DATA_CHOICES: ClassVar[set] = {
         'stats',
         'stats_sum',
+        'stats_reqs',
         'dashboard-v2',
         'livelog',
         'tree',

--- a/bublik/interfaces/api_v2/results.py
+++ b/bublik/interfaces/api_v2/results.py
@@ -270,8 +270,10 @@ class ResultViewSet(ModelViewSet):
         )
 
     def list(self, request):
-        results = self.paginate_queryset(self.get_queryset())
-        return self.get_paginated_response(generate_results_details(results))
+        return Response(
+            data={'results': generate_results_details(self.get_queryset())},
+            status=status.HTTP_200_OK,
+        )
 
     @action(detail=True, methods=['get'])
     def artifacts_and_verdicts(self, request, pk=None):

--- a/bublik/interfaces/api_v2/results.py
+++ b/bublik/interfaces/api_v2/results.py
@@ -144,6 +144,16 @@ class RunViewSet(ModelViewSet):
         return Response({'results': get_run_stats_detailed_with_comments(run.id, requirements)})
 
     @action(detail=True, methods=['get'])
+    def requirements(self, request, pk=None):
+        run = self.get_object()
+        run_requirements = sorted(
+            models.Meta.objects.filter(type='requirement', metaresult__result__test_run=run)
+            .values_list('value', flat=True)
+            .distinct(),
+        )
+        return Response({'requirements': run_requirements})
+
+    @action(detail=True, methods=['get'])
     def source(self, request, pk=None):
         run = self.get_object()
         return Response({'url': get_sources(run)})


### PR DESCRIPTION
## Done ##
1. Fix #138
2. Fix #156
3. Fix #155 

## The new endpoint overview ##
### Description ###
The new endpoint allows you to retrieve a list of all requirements found in the results of test run iterations.

### Usage ###
Request: `GET /bublik/api/v2/runs/<run ID>/requirements/`
Response data:
```
{
    "requirements": [
        "FLOW_TRANSFER",
        "GENEVE",
        "I40E_UNSTABLE",
        "NO_TEST_HARNESS_CHECKUP",
        "OUTER_IP4",
        "OUTER_IP6",
        "RSS",
        "RX_JUMBO",
        "RX_SCATTER",
        "TEREDO",
        "TEST_HARNESS_CHECKUP",
        "TSO",
        "TSO_ENCAP",
        "TX_MULTI_SEG",
        "VLAN_INSERT",
        "VXLAN"
    ]
}
```
Response status code: 200