### PR TITLE
Add compatibility for docker deploy

### DIFF
--- a/bublik/interfaces/api_v2/log.py
+++ b/bublik/interfaces/api_v2/log.py
@@ -53,18 +53,20 @@ class LogViewSet(RetrieveModelMixin, GenericViewSet):
 
         if not result.test_run:
             # The file `node_1_0.json` contains TE startup log in JSON
-            json_tail = 'json/node_1_0.json'
+            json_tail = 'json/node_1_0'
         else:
             json_tail = f'json/node_id{result.exec_seqno}'
             if page == '0':
-                json_tail += '_all.json'
+                json_tail += '_all'
             elif page:
-                json_tail += f'_p{page}.json'
-            else:
-                json_tail += '.json'
+                json_tail += f'_p{page}'
 
-        url = os.path.join(run_source_link, json_tail)
-        return Response(data={'url': url}, status=status.HTTP_200_OK)
+        url = os.path.join(run_source_link, json_tail + '.json')
+        artifacts_url = os.path.join(run_source_link, json_tail, 'artifacts.json')
+        return Response(
+            data={'url': url, 'artifacts_url': artifacts_url},
+            status=status.HTTP_200_OK,
+        )
 
     @action(detail=True, methods=['get'])
     def html(self, request, pk=None):

--- a/templates/settings.py.template
+++ b/templates/settings.py.template
@@ -45,6 +45,10 @@ DEBUG = False
 
 ALLOWED_HOSTS = ['*']
 
+# The following settings are only used in Docker deployment and added for compatibility
+SECURE_HTTP = False
+ENABLE_JSON_LOGS_PROXY = False
+
 # For debug panel. Note, that you might need
 # ./scripts/manage collectstatic
 INTERNAL_IPS = ['127.0.0.1']


### PR DESCRIPTION
## Description
This PR implements a proxy functionality for JSON logs to handle cross-origin resource sharing (CORS) issues.
This add compatibility between deploy without docker and deploy with docker, please see https://github.com/ts-factory/bublik-docker

### Key Changes
- Added a new proxy endpoint `/api/v2/logs/proxy/` that forwards requests to log files
- Added new configuration settings:
  - `SECURE_HTTP`: Flag to control HTTP/HTTPS protocol usage
  - `ENABLE_JSON_LOGS_PROXY`: Toggle for the proxy functionality

### Configuration
Two new settings have been added to `settings.py.template`:
```python
SECURE_HTTP = False
ENABLE_JSON_LOGS_PROXY = False
```