### PR TITLE
Run stats: fix issue link building

### DIFF
--- a/bublik/core/run/stats.py
+++ b/bublik/core/run/stats.py
@@ -528,7 +528,7 @@ def get_expected_results(result):
                     default={},
                 )
                 if ref_type in logs and ref_tail:
-                    ref_uri = logs[ref_type]['uri'][0]
+                    ref_uri = logs[ref_type]['uri']
                     ref_url = f'{ref_uri}{ref_tail}'
                     key_part['url'] = ref_url
 


### PR DESCRIPTION
It is required to modify the way the URI for issues is retrieved from the references configuration, as the URI value is now a string instead of a list of strings.