### PR TITLE
Requirements: update packages versions to pick up bug fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ cffi==1.15.0
 chardet==3.0.4
 click==8.1.2
 coverage==5.3
-cryptography==43.0.3
+cryptography==44.0.1
 deepdiff==6.2.3
 Dickens==2.0.0
 django-admin==1.3.2
@@ -32,7 +32,7 @@ django-lint==2.0.4
 django-redis-cache==3.0.1
 django-six==1.0.4
 django-static-jquery==2.1.4
-Django==5.1.3
+Django==5.1.7
 djangorestframework-simplejwt
 djangorestframework==3.15.2
 drf-spectacular-sidecar==2024.11.1


### PR DESCRIPTION
Upgrade Django to version 5.1.7 and Cryptography to version 44.0.1.