### PR TITLE
Requirements: update packages versions to pick up bug fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ django-cachalot==2.7.0
 django-debug-toolbar==5.0.1
 django-excel-response2==2.0.8
 django-extensions==3.1.5
-django-filter==21.1
+django-filter==25.1
 django-lint==2.0.4
 django-redis-cache==3.0.1
 django-six==1.0.4


### PR DESCRIPTION
Upgrade Django-filter to version 25.1 to fix compatibility issues with Django version 5.1.7.