### PR TITLE
Deploy: fix logilab-astng install

### DIFF
--- a/scripts/deploy
+++ b/scripts/deploy
@@ -197,6 +197,7 @@ function install_server_packages() {
     redis-server
     libffi-dev
     libkrb5-dev
+    2to3
 )
   if test -n "${KEYTAB}" ; then
     packages+=("kstart krb5-user")


### PR DESCRIPTION
Add 2to3 package which is required to build Python logilab-astng.