### PR TITLE
log: add proxy logic for JSON logs to fix CORS issues

### DIFF
--- a/bublik/interfaces/api_v2/log.py
+++ b/bublik/interfaces/api_v2/log.py
@@ -67,6 +67,20 @@ class LogViewSet(RetrieveModelMixin, GenericViewSet):
 
         url = os.path.join(run_source_link, 'json', node + '.json')
         attachments_url = os.path.join(run_source_link, 'attachments', node, 'attachments.json')
+
+        if settings.ENABLE_JSON_LOGS_PROXY:
+            parsed_url = urlparse(request.build_absolute_uri())
+            origin = f"{'https' if settings.SECURE_HTTP else 'http'}://{parsed_url.netloc}"
+            forwarding_url = f'{origin}{settings.PREFIX}/api/v2/logs/proxy/?url={url}'
+            attachments_url = (
+                f'{origin}{settings.PREFIX}/api/v2/logs/proxy/?url={attachments_url}'
+            )
+
+            return Response(
+                data={'url': forwarding_url, 'attachments_url': attachments_url},
+                status=status.HTTP_200_OK,
+            )
+
         return Response(
             data={'url': url, 'attachments_url': attachments_url},
             status=status.HTTP_200_OK,


### PR DESCRIPTION
@arybchik
Rearranging patches resulted in some missing code for CORS patch
Deeply sorry :(

This patch adds the missing proxy logic for JSON log URLs to resolve CORS issues when accessing logs from the frontend.

- Applies proxying to both url and attachments_url when ENABLE_JSON_LOGS_PROXY is enabled.
- Constructs forwarding URLs using the request origin and the configured API prefix.

Related to commit add49cfbcf6c9b3f836547ec1560e6a2824be05f