### PR TITLE
ci: add code quality check workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,93 @@
+name: Code Quality
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  detect-changes:
+    name: Detect Changed Python Files
+    runs-on: ubuntu-latest
+    outputs:
+      python_files: ${{ steps.changed.outputs.all_changed_files }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get changed Python files
+        id: changed
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
+        with:
+          files: |
+            **/*.py
+
+  format-check:
+    name: Check Code Formatting
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    if: ${{ needs.detect-changes.outputs.python_files != '' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Black
+        run: pip install black
+
+      - name: Run Black in check mode
+        run: |
+          echo "${{ needs.detect-changes.outputs.python_files }}" | xargs black --check --diff
+
+  lint-check:
+    name: Check Code Quality
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    if: ${{ needs.detect-changes.outputs.python_files != '' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Ruff
+        run: pip install ruff
+
+      - name: Run Ruff
+        run: |
+          echo "${{ needs.detect-changes.outputs.python_files }}" | xargs ruff check
+
+  f-string-check:
+    name: Check F-String Usage
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    if: ${{ needs.detect-changes.outputs.python_files != '' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Flynt
+        run: pip install flynt
+
+      - name: Run Flynt in check mode
+        run: |
+          echo "${{ needs.detect-changes.outputs.python_files }}" | xargs flynt -f
+
+  quote-style-check:
+    name: Check Quote Style Consistency
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    if: ${{ needs.detect-changes.outputs.python_files != '' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Unify
+        run: pip install unify
+
+      - name: Run Unify in check mode
+        run: |
+          echo "${{ needs.detect-changes.outputs.python_files }}" | xargs unify -c --quote "'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [tool.ruff]
-
 line-length = 96
+target-version = 'py38'
+
+[tool.ruff.lint]
 select = [
     # pyflakes
     'F',
@@ -89,11 +91,10 @@ exclude = [
     'tests',
     'migrations',
 ]
-target-version = 'py38'
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 'bublik/settings.py' = [
-    # there is an import of per_conf that can't be moved to the top of the file
+    # There is an import of per_conf that can't be moved to the top of the file
     'E402',
     'I001',
 ]
@@ -102,15 +103,15 @@ target-version = 'py38'
     'C901',
 ]
 'bublik/data/*' = [
-    # in order to keep the structure of DB the same
+    # In order to keep the structure of DB the same
     'A003',
-    # keep the null=True for string-based fields
+    # Keep the null=True for string-based fields
     'DJ001',
-    # use __repr__ instead of __str__
+    # Use __repr__ instead of __str__
     'DJ008',
 ]
 'bublik/interfaces/*' = [
-    # in order to keep the structure of UI the same
+    # In order to keep the structure of UI the same
     'A',
 ]
 'bublik/interfaces/api_v2/history.py' = [
@@ -130,31 +131,27 @@ target-version = 'py38'
     'C901',
 ]
 
-[tool.ruff.flake8-quotes]
+[tool.ruff.lint.flake8-quotes]
 avoid-escape = false
 inline-quotes = 'single'
 docstring-quotes = 'single'
 multiline-quotes = 'single'
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 16
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 force-sort-within-sections = true
 split-on-trailing-comma = true
 lines-after-imports = 2
-lines-between-types = 1
 
-[tool.black]
-line-length = 96
-target-version = ['py38']
-avoid-escape = false
-inline-quotes = 'single'
-docstring-quotes = 'single'
-multiline-quotes = 'single'
-
-[tool.ruff.pylint]
+[tool.ruff.lint.pylint]
 max-args = 8
 max-branches = 30
 max-statements = 100
 max-returns = 7
+
+[tool.black]
+line-length = 96
+target-version = ['py38']
+skip-string-normalization = true


### PR DESCRIPTION

## Added CI checks for linting and formatting: 
- The CI now runs checks on every PR to the main branch to ensure consistent formatting and linting across the codebase.
- Resolved deprecation warnings for ruff configuration:
- Moved linter settings to the new lint section in pyproject.toml, as per the latest ruff guidelines.
- Updated settings for ignore, `select`, `flake8-quotes`, `isort`, `mccabe`, and `pylint` under the lint section.

## Selective linting on changed files:
- Linting and formatting checks will only run on the files that have changed in the PR. 
- This allows for gradual adoption of new style rules without requiring large-scale refactoring of existing code.

## Warnings Fixed:
The following warnings were addressed in the pyproject.toml configuration:
1. Deprecation: Moved top-level linter settings to the lint section.
2. Unused config: Fixed lines-between-types being ignored due to force-sort-within-sections being set to true.

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'flake8-quotes' -> 'lint.flake8-quotes'
  - 'isort' -> 'lint.isort'
  - 'mccabe' -> 'lint.mccabe'
  - 'pylint' -> 'lint.pylint'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
warning: `lines-between-types` is ignored when `force-sort-within-sections` is set to `true`
```