### PR TITLE
Update the run log and results JSON structures

### DIFF
--- a/bublik/core/history/v2/utils.py
+++ b/bublik/core/history/v2/utils.py
@@ -46,15 +46,9 @@ def prepare_list_results(
         result_finish = test_result['finish']
 
         # Handle expected result
-        expected_result_data = {}
         test_result_obj = TestIterationResult.objects.get(id=result_id)
         expected_results = get_expected_results(test_result_obj)
-        if expected_results:
-            expected_result = expected_results[0]
-            expected_result_data = {
-                'result_type': expected_result['result'],
-                'verdict': expected_result['verdicts'],
-            }
+        expected_result_data = expected_results[0] if expected_results else {}
 
         # Handle obtained result
         obtained_result_data = {

--- a/bublik/core/history/v2/utils.py
+++ b/bublik/core/history/v2/utils.py
@@ -47,8 +47,7 @@ def prepare_list_results(
 
         # Handle expected result
         test_result_obj = TestIterationResult.objects.get(id=result_id)
-        expected_results = get_expected_results(test_result_obj)
-        expected_result_data = expected_results[0] if expected_results else {}
+        expected_results_data = get_expected_results(test_result_obj)
 
         # Handle obtained result
         obtained_result_data = {
@@ -67,7 +66,7 @@ def prepare_list_results(
             'finish_date': display_to_milliseconds(result_finish),
             'duration': get_duration(result_start, result_finish),
             'obtained_result': obtained_result_data,
-            'expected_result': expected_result_data,
+            'expected_results': expected_results_data,
             'important_tags': important_tags.get(run_id, []),
             'relevant_tags': relevant_tags.get(run_id, []),
             'metadata': metadata,

--- a/bublik/core/history/v2/utils.py
+++ b/bublik/core/history/v2/utils.py
@@ -52,7 +52,7 @@ def prepare_list_results(
         # Handle obtained result
         obtained_result_data = {
             'result_type': results[result_id],
-            'verdict': verdicts.get(result_id, []),
+            'verdicts': verdicts.get(result_id, []),
         }
 
         # Handle parameters

--- a/bublik/core/history/v2/utils.py
+++ b/bublik/core/history/v2/utils.py
@@ -3,7 +3,6 @@
 
 from datetime import datetime, timedelta
 import hashlib
-
 from itertools import groupby
 import urllib
 

--- a/bublik/core/importruns/milog.py
+++ b/bublik/core/importruns/milog.py
@@ -4,7 +4,6 @@
 from collections import Counter
 from datetime import datetime, timedelta
 from itertools import groupby
-import json
 import logging
 from typing import ClassVar
 
@@ -302,26 +301,15 @@ class HandlerArtifacts:
     def __init__(self, test_iter_result):
         self.test_iter_result = test_iter_result
 
-    def handle(self, artifacts):
-        #
-        # After fix in script/xml_log_parse
-        # this function will be changed.
-        #
+    def handle_artifacts(self, artifacts):
         for artifact in artifacts:
-            try:
-                mi_log = json.loads(artifact)
-                self.handle_mi_artifact(mi_log)
-            except json.decoder.JSONDecodeError:
-                self.handle_artifact(artifact)
-
-    def handle_artifact(self, artifact):
-        m_data = {'type': 'artifact', 'value': artifact}
-        mr_serializer = serialize(
-            MetaResultSerializer,
-            {'meta': m_data, 'result': self.test_iter_result.id},
-            logger,
-        )
-        mr_serializer.get_or_create()
+            m_data = {'type': 'artifact', 'value': artifact}
+            mr_serializer = serialize(
+                MetaResultSerializer,
+                {'meta': m_data, 'result': self.test_iter_result.id},
+                logger,
+            )
+            mr_serializer.get_or_create()
 
     def handle_existing_mi_artifact(self, artifact):
         try:
@@ -364,49 +352,50 @@ class HandlerArtifacts:
             logger.error(e)
             logger.error('Failed to process views')
 
-    def handle_mi_artifact(self, mi_log):
-        start_time = datetime.now()
-        try:
-            results = InstanceLevel.pop(mi_log, 'results', True)
-            views = InstanceLevel.pop(mi_log, 'views', False)
-            commonlvl = CommonLevel(mi_log)
+    def handle_mi_artifacts(self, artifacts):
+        for artifact in artifacts:
+            start_time = datetime.now()
+            try:
+                results = InstanceLevel.pop(artifact, 'results', True)
+                views = InstanceLevel.pop(artifact, 'views', False)
+                commonlvl = CommonLevel(artifact)
 
-            for result in results:
-                entries = InstanceLevel.pop(result, 'entries', True)
-                resultlvl = ResultLevel(result, commonlvl)
+                for result in results:
+                    entries = InstanceLevel.pop(result, 'entries', True)
+                    resultlvl = ResultLevel(result, commonlvl)
 
-                def entries_by_measurements(entry):
-                    return [entry['aggr'], entry['base_units'], entry['multiplier']]
+                    def entries_by_measurements(entry):
+                        return [entry['aggr'], entry['base_units'], entry['multiplier']]
 
-                entries = sorted(entries, key=entries_by_measurements)
-                serial = -1
-                for _, entries_group in groupby(entries, key=entries_by_measurements):
-                    serial += 1
-                    entries_group = list(entries_group)
-                    values = [entry['value'] for entry in entries_group]
-                    entry = entries_group[0]
-                    entry['value'] = values
-                    try:
-                        entrylvl = EntryLevel(entry, serial, resultlvl)
-                        entrylvl.save(self.test_iter_result)
-                    except KeyError as ke:
-                        ke = str(ke).replace("'", '')
-                        logger.error(f'invalid MI log format: {ke}')
-                    except ValueError as ve:
-                        ve = str(ve).replace("'", '')
-                        logger.warning(f'{ve}. Check your MI logs.')
+                    entries = sorted(entries, key=entries_by_measurements)
+                    serial = -1
+                    for _, entries_group in groupby(entries, key=entries_by_measurements):
+                        serial += 1
+                        entries_group = list(entries_group)
+                        values = [entry['value'] for entry in entries_group]
+                        entry = entries_group[0]
+                        entry['value'] = values
+                        try:
+                            entrylvl = EntryLevel(entry, serial, resultlvl)
+                            entrylvl.save(self.test_iter_result)
+                        except KeyError as ke:
+                            ke = str(ke).replace("'", '')
+                            logger.error(f'invalid MI log format: {ke}')
+                        except ValueError as ve:
+                            ve = str(ve).replace("'", '')
+                            logger.warning(f'{ve}. Check your MI logs.')
 
-            if views is not None:
-                self.handle_views(views)
+                if views is not None:
+                    self.handle_views(views)
 
-            HandlerArtifacts.handle_meas_time += datetime.now() - start_time
+                HandlerArtifacts.handle_meas_time += datetime.now() - start_time
 
-        except Exception as e:
-            e = str(e).replace("'", '')
-            logger.error(
-                f'invalid MI log format: {e}. Handling of the current MI log is completed '
-                f'without saving.',
-            )
-        finally:
-            Saver.single_measurements.clear()
-            Saver.list_measurements.clear()
+            except Exception as e:
+                e = str(e).replace("'", '')
+                logger.error(
+                    f'invalid MI log format: {e}. Handling of the current MI log is completed '
+                    f'without saving.',
+                )
+            finally:
+                Saver.single_measurements.clear()
+                Saver.list_measurements.clear()

--- a/bublik/core/importruns/telog.py
+++ b/bublik/core/importruns/telog.py
@@ -260,6 +260,8 @@ class JSONLog:
             self.process_dir = process_dir
             self.path_json_log = os.path.join(self.process_dir, self.json_filename)
 
+        if os.path.exists(os.path.join(self.process_dir, 'bublik.json')):
+            return self.load()
         if os.path.exists(os.path.join(self.process_dir, 'bublik.xml')):
             return self.convert_from_bublik_xml('bublik.xml')
         if os.path.exists(os.path.join(self.process_dir, 'log.json.xz')):

--- a/bublik/core/importruns/telog.py
+++ b/bublik/core/importruns/telog.py
@@ -246,7 +246,10 @@ class JSONLog:
         return self.load()
 
     def convert_from_bublik_xml(self, from_filename):
-        XMLLog(path_in=os.path.join(self.process_dir, from_filename), path_out=self.path_json_log).convert()
+        XMLLog(
+            path_in=os.path.join(self.process_dir, from_filename),
+            path_out=self.path_json_log,
+        ).convert()
 
         return self.load()
 

--- a/bublik/core/run/objects.py
+++ b/bublik/core/run/objects.py
@@ -316,7 +316,7 @@ def add_expected_result(
     result,
     verdicts=None,
     tag_expression=None,
-    key=None,
+    keys=None,
     notes=None,
 ):
     expect_metas = []
@@ -333,15 +333,13 @@ def add_expected_result(
     if tag_expression is not None:
         expect_metas.append({'meta': {'type': 'tag_expression', 'value': tag_expression}})
 
-    if key is not None:
-        expect_metas.extend(prepare_expected_key(key))
+    if keys:
+        for key in keys:
+            expect_metas.extend(prepare_expected_key(key))
 
-    if notes is not None:
-        if isinstance(notes, (list, tuple, set)):
-            for index, note in enumerate(notes):
-                expect_metas.append({'meta': {'type': 'note', 'value': note}, 'serial': index})
-        else:
-            expect_metas.append({'meta': {'type': 'note', 'value': notes}})
+    if notes:
+        for index, note in enumerate(notes):
+            expect_metas.append({'meta': {'type': 'note', 'value': note}, 'serial': index})
 
     expectation_serializer = serialize(
         ExpectationSerializer,

--- a/bublik/core/run/stats.py
+++ b/bublik/core/run/stats.py
@@ -739,8 +739,7 @@ def generate_results_details(test_results):
         iteration_id = iteration.id
 
         # Handle expected result
-        expected_results = get_expected_results(test_result)
-        expected_result_data = expected_results[0] if expected_results else {}
+        expected_results_data = get_expected_results(test_result)
 
         # Handle obtained result and comments
         result_type = None
@@ -780,7 +779,7 @@ def generate_results_details(test_results):
             'iteration_id': iteration_id,
             'start': test_result.start,
             'obtained_result': obtained_result_data,
-            'expected_result': expected_result_data,
+            'expected_results': expected_results_data,
             'artifacts': artifacts,
             'parameters': parameters_list,
             'comments': comments,

--- a/bublik/core/run/stats.py
+++ b/bublik/core/run/stats.py
@@ -532,8 +532,8 @@ def get_expected_results(result):
         meta_expect = expectation.expectmeta_set.all()
         expected_result = {
             'result_type': None,
-            'verdict': [],
-            'key': [],
+            'verdicts': [],
+            'keys': [],
         }
 
         meta_expect_results = meta_expect.filter(meta__type='result')
@@ -543,7 +543,7 @@ def get_expected_results(result):
 
         meta_expect_results = meta_expect.filter(meta__type='verdict_expected')
         if meta_expect_results.exists():
-            expected_result['verdict'] = list(
+            expected_result['verdicts'] = list(
                 meta_expect_results.all()
                 .order_by('serial')
                 .values_list('meta__value', flat=True),
@@ -558,7 +558,7 @@ def get_expected_results(result):
                 key_info_part = key_string.partition(ref)[0]
                 if key_info_part:
                     key_part = {'name': key_info_part, 'url': None}
-                    expected_result['key'].append(key_part)
+                    expected_result['keys'].append(key_part)
 
                 # Parse the ref
                 ref_type, ref_tail = re.search(r'ref://(.*)/(.*)', ref).group(1, 2)
@@ -578,7 +578,7 @@ def get_expected_results(result):
                     ref_url = f'{ref_uri}{ref_tail}'
                     key_part['url'] = ref_url
 
-                expected_result['key'].append(key_part)
+                expected_result['keys'].append(key_part)
 
                 # Trim the key string by the current ref
                 key_string = key_string.partition(ref)[2]
@@ -586,7 +586,7 @@ def get_expected_results(result):
             # Add what is left in the key string
             if key_string:
                 key_part = {'name': key_string, 'url': None}
-                expected_result['key'].append(key_part)
+                expected_result['keys'].append(key_part)
 
         expected_results.append(expected_result)
     return expected_results
@@ -743,7 +743,7 @@ def generate_results_details(test_results):
 
         # Handle obtained result and comments
         result_type = None
-        verdict = []
+        verdicts = []
         artifacts = []
         comments = []
         requirements = []
@@ -752,7 +752,7 @@ def generate_results_details(test_results):
             if meta_result.meta.type == 'result':
                 result_type = meta_result.meta.value
             elif meta_result.meta.type == 'verdict':
-                verdict.append(meta_result.meta.value)
+                verdicts.append(meta_result.meta.value)
             elif meta_result.meta.type == 'artifact':
                 artifacts.append(meta_result.meta.value)
             elif meta_result.meta.type == 'note':
@@ -762,7 +762,7 @@ def generate_results_details(test_results):
 
         obtained_result_data = {
             'result_type': result_type,
-            'verdict': verdict,
+            'verdicts': verdicts,
         }
 
         # Handle parameters

--- a/bublik/core/run/stats.py
+++ b/bublik/core/run/stats.py
@@ -531,19 +531,19 @@ def get_expected_results(result):
     for expectation in result.expectations.all():
         meta_expect = expectation.expectmeta_set.all()
         expected_result = {
-            'result': None,
-            'verdicts': [],
+            'result_type': None,
+            'verdict': [],
             'key': [],
         }
 
         meta_expect_results = meta_expect.filter(meta__type='result')
         if not meta_expect_results.exists():
             continue
-        expected_result['result'] = meta_expect_results.first().meta.value
+        expected_result['result_type'] = meta_expect_results.first().meta.value
 
         meta_expect_results = meta_expect.filter(meta__type='verdict_expected')
         if meta_expect_results.exists():
-            expected_result['verdicts'] = list(
+            expected_result['verdict'] = list(
                 meta_expect_results.all()
                 .order_by('serial')
                 .values_list('meta__value', flat=True),
@@ -739,15 +739,8 @@ def generate_results_details(test_results):
         iteration_id = iteration.id
 
         # Handle expected result
-        expected_result_data = {}
         expected_results = get_expected_results(test_result)
-        if expected_results:
-            expected_result = expected_results[0]
-            expected_result_data = {
-                'result_type': expected_result['result'],
-                'verdict': expected_result['verdicts'],
-                'key': expected_result['key'],
-            }
+        expected_result_data = expected_results[0] if expected_results else {}
 
         # Handle obtained result and comments
         result_type = None

--- a/bublik/interfaces/management/commands/importruns.py
+++ b/bublik/interfaces/management/commands/importruns.py
@@ -183,6 +183,8 @@ class Command(BaseCommand):
             for log_file in log_files:
                 if save_url_to_dir(run_url, process_dir, log_file):
                     json_data = JSONLog().convert_from_dir(process_dir)
+                    url_str = os.path.join(run_url, log_file)
+                    logger.info(f'run logs were downloaded from {url_str}')
                     break
 
             if meta_data_saved:

--- a/bublik/interfaces/management/commands/importruns.py
+++ b/bublik/interfaces/management/commands/importruns.py
@@ -179,10 +179,19 @@ class Command(BaseCommand):
             meta_data_saved = save_url_to_dir(run_url, process_dir, 'meta_data.json')
 
             # Fetch available logs, convert and load JSON log
-            log_files = ['bublik.xml', 'log.json.xz', 'log.xml.xz', 'raw_log_bundle.tpxz']
+            log_files = [
+                'bublik.json',
+                'bublik.xml',
+                'log.json.xz',
+                'log.xml.xz',
+                'raw_log_bundle.tpxz',
+            ]
             for log_file in log_files:
                 if save_url_to_dir(run_url, process_dir, log_file):
-                    json_data = JSONLog().convert_from_dir(process_dir)
+                    if log_file == 'bublik.json':
+                        json_data = JSONLog().convert_from_dir(process_dir, log_file)
+                    else:
+                        json_data = JSONLog().convert_from_dir(process_dir)
                     url_str = os.path.join(run_url, log_file)
                     logger.info(f'run logs were downloaded from {url_str}')
                     break

--- a/bublik/interfaces/management/commands/importruns.py
+++ b/bublik/interfaces/management/commands/importruns.py
@@ -178,14 +178,12 @@ class Command(BaseCommand):
             # Fetch meta_data.json if available
             meta_data_saved = save_url_to_dir(run_url, process_dir, 'meta_data.json')
 
-            # Fetch available logs
-            if not save_url_to_dir(run_url, process_dir, 'bublik.xml'):
-                if not save_url_to_dir(run_url, process_dir, 'log.json.xz'):
-                    if not save_url_to_dir(run_url, process_dir, 'log.xml.xz'):
-                        save_url_to_dir(run_url, process_dir, 'raw_log_bundle.tpxz')
-
-            # Convert and load JSON log
-            json_data = JSONLog().convert_from_dir(process_dir)
+            # Fetch available logs, convert and load JSON log
+            log_files = ['bublik.xml', 'log.json.xz', 'log.xml.xz', 'raw_log_bundle.tpxz']
+            for log_file in log_files:
+                if save_url_to_dir(run_url, process_dir, log_file):
+                    json_data = JSONLog().convert_from_dir(process_dir)
+                    break
 
             if meta_data_saved:
                 # Load meta_data.json

--- a/scripts/xml_log_parser
+++ b/scripts/xml_log_parser
@@ -5,6 +5,7 @@
 use strict;
 use warnings;
 use XML::Parser;
+use Date::Parse;
 use JSON;
 use English;
 use POSIX;
@@ -35,6 +36,280 @@ my $base_date = "";
 
 my @cur_nodes = ();
 
+sub parse_result
+{
+    my ($line_idx, $lines) = @_;
+    my $lines_num = scalar(@{$lines});
+    my $line;
+    my $parsed = {};
+
+    $line = $lines->[$line_idx];
+    if ($line =~ /^\s*([A-Z]+)(\s+with verdicts:)?\s*$/)
+    {
+        $parsed->{status} = $1;
+
+        if ($2)
+        {
+            $parsed->{verdicts} = [];
+
+            for ($line_idx++; $line_idx < $lines_num; $line_idx++)
+            {
+                $line = $lines->[$line_idx];
+
+                if ($line =~ /^(.*);$/)
+                {
+                    push(@{$parsed->{verdicts}}, $1)
+                }
+                else
+                {
+                    last;
+                }
+            }
+        }
+    }
+    else
+    {
+        return ($line_idx, $parsed);
+    }
+
+    for ( ; $line_idx < $lines_num; $line_idx++)
+    {
+        $line = $lines->[$line_idx];
+
+        if ($line =~ /^Key:\s*(.*)$/)
+        {
+            $parsed->{key} = $1;
+        }
+        elsif ($line =~ /^Notes:\s*(.*)$/)
+        {
+            $parsed->{notes} = $1;
+        }
+
+        last if (length($line) == 0);
+    }
+
+    if ($line_idx < $lines_num - 1)
+    {
+        $line = $lines->[$line_idx + 1];
+        if ($line =~ /^Artifacts:/)
+        {
+            $parsed->{artifacts} = [];
+            for ($line_idx += 2; $line_idx < $lines_num; $line_idx++)
+            {
+                $line = $lines->[$line_idx];
+
+                if ($line =~ /^(.*);$/)
+                {
+                    push(@{$parsed->{artifacts}}, $1)
+                }
+                else
+                {
+                    last;
+                }
+            }
+        }
+    }
+
+    return ($line_idx, $parsed);
+}
+
+sub parse_tester_end_msg
+{
+    my $lines = $_[0];
+    my $lines_num = scalar(@{$lines});
+    my $obtained = {};
+    my $expected = {};
+    my $exp_parsed = 0;
+    my $start_parsing = 0;
+
+    for (my $line_idx = 0; $line_idx < $lines_num; $line_idx++)
+    {
+        my $result;
+        my $line;
+
+        $line = $lines->[$line_idx];
+        next if length($line) == 0;
+
+        if ($line =~ /^Obtained result is:/)
+        {
+            $exp_parsed = 0;
+            $start_parsing = 1;
+            next;
+        }
+        elsif ($line =~ /^Expected results are:\s*(.*)$/)
+        {
+            $exp_parsed = 1;
+
+            if ($1 ne 'default')
+            {
+                $expected->{tag_expression} = $1;
+            }
+
+            $start_parsing = 1;
+            next;
+        }
+
+        next if (not $start_parsing);
+
+        if ($exp_parsed and $line =~ /^Key:\s*(.*)$/)
+        {
+            $expected->{key} = $1;
+        }
+        elsif ($exp_parsed and $line =~ /^Notes:\s*(.*)$/)
+        {
+            $expected->{notes} = $1;
+        }
+        else
+        {
+            ($line_idx, $result) = parse_result($line_idx, $lines);
+            if (%$result)
+            {
+                if ($exp_parsed)
+                {
+                    if (not exists($expected->{results}))
+                    {
+                        $expected->{results} = [];
+                    }
+
+                    push(@{$expected->{results}}, $result);
+                }
+                else
+                {
+                    $obtained = $result;
+                }
+            }
+        }
+    }
+
+    return ($obtained, $expected);
+}
+
+sub results_cmp
+{
+    my ($res1, $res2) = @_;
+    my $st1 = "";
+    my $st2 = "";
+    my $v1 = [];
+    my $v2 = [];
+    my $v1_len = 0;
+    my $v2_len = 0;
+
+    if (defined($res1->{status}))
+    {
+        $st1 = $res1->{status};
+    }
+    if (defined($res2->{status}))
+    {
+        $st2 = $res2->{status};
+    }
+    if (defined($res1->{verdicts}))
+    {
+        $v1 = $res1->{verdicts};
+        $v1_len = scalar(@{$v1});
+    }
+    if (defined($res2->{verdicts}))
+    {
+        $v2 = $res2->{verdicts};
+        $v2_len = scalar(@{$v2});
+    }
+
+    if ($st1 ne $st2)
+    {
+        return 0;
+    }
+
+    if ($v1_len != $v2_len)
+    {
+        return 0;
+    }
+
+    for (my $i = 0; $i < $v1_len; $i++)
+    {
+        if ($v1->[$i] ne $v2->[$i])
+        {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+sub fix_results
+{
+    # Make results fields similar to what rgt-bublik-json generates.
+    # If obtained result is expected, then key and notes should be
+    # copied from the matching expected result and 'expected' field
+    # should be removed.
+    my $iter = $_[0];
+    my $exp;
+    my $r_obt;
+    my $r_exp;
+
+    if (defined($iter->{obtained}))
+    {
+        # This is done to make possible saving key/notes from
+        # <results> in TRC along with key/notes from <result>.
+        $iter->{obtained} = {"result" => $iter->{obtained}};
+    }
+
+    if ($iter->{err} eq "Unexpected test result(s)")
+    {
+        return;
+    }
+
+    if (not defined($iter->{obtained}) or not defined($iter->{expected}))
+    {
+        return;
+    }
+
+    $r_obt = $iter->{obtained}->{result};
+    $exp = $iter->{expected};
+
+    if (defined($exp->{results}))
+    {
+        my $results = $exp->{results};
+
+        for (my $i = 0; $i < scalar(@{$results}); $i++)
+        {
+            if (results_cmp($r_obt, $results->[$i]))
+            {
+                $r_exp = $results->[$i];
+                last;
+            }
+        }
+    }
+
+    if (defined($r_exp))
+    {
+        if (defined($exp->{notes}))
+        {
+            $iter->{obtained}->{notes} = $exp->{notes};
+        }
+
+        if (defined($exp->{key}))
+        {
+            $iter->{obtained}->{key} = $exp->{key};
+        }
+
+        if (defined($exp->{tag_expression}))
+        {
+            $iter->{obtained}->{tag_expression} = $exp->{tag_expression};
+        }
+
+        if (defined($r_exp->{notes}))
+        {
+            $r_obt->{notes} = $r_exp->{notes};
+        }
+
+        if (defined($r_exp->{key}))
+        {
+            $r_obt->{key} = $r_exp->{key};
+        }
+
+        delete($iter->{expected});
+    }
+}
+
 sub handle_start
 {
     my ($p, $e, %attrs) = @_;
@@ -50,6 +325,13 @@ sub handle_start
     $p->{tags} = '';
     $p->{plan_parsed} = 0;
     $p->{plan} = '';
+    $p->{objective} = '';
+    $p->{level} = '';
+
+    if (defined($attrs{level}))
+    {
+        $p->{level} = $attrs{level};
+    }
 
     if ($e eq "pkg" || $e eq "session" ||
         $e eq "test")
@@ -72,15 +354,11 @@ sub handle_start
         $cur_iter->{tin} = -1;
         $cur_iter->{test_id} = -1;
         $cur_iter->{plan_id} = -1;
-        $cur_iter->{result} = "";
         $cur_iter->{err} = "";
-        $cur_iter->{result_expected} = "";
         $cur_iter->{objective} = "";
-        $cur_iter->{verdicts} = [];
-        $cur_iter->{verdicts_expected} = [];
-        $cur_iter->{artifacts} = [];
         $cur_iter->{iters} = [];
         $cur_iter->{type} = $e;
+        $cur_iter->{obtained} = {};
 
         if (defined($attrs{hash}))
         {
@@ -88,19 +366,19 @@ sub handle_start
         }
         if (defined($attrs{tin}))
         {
-            $cur_iter->{tin} = $attrs{tin};
+            $cur_iter->{tin} = int($attrs{tin});
         }
         if (defined($attrs{test_id}))
         {
-            $cur_iter->{test_id} = $attrs{test_id};
+            $cur_iter->{test_id} = int($attrs{test_id});
         }
         if (defined($attrs{plan_id}))
         {
-            $cur_iter->{plan_id} = $attrs{plan_id};
+            $cur_iter->{plan_id} = int($attrs{plan_id});
         }
         if (defined($attrs{result}))
         {
-            $cur_iter->{result} = $attrs{result};
+            $cur_iter->{obtained}->{status} = $attrs{result};
         }
         if (defined($attrs{err}))
         {
@@ -162,49 +440,56 @@ sub handle_start
 sub handle_char
 {
     my ($p, $str) = @_;
+    my $cur_elm = $p->current_element();
 
-    if ($p->current_element() eq "start-ts")
+    if (defined($cur_elm))
     {
-        $p->{start_ts} .= $str;
-    }
-    elsif ($p->current_element() eq "end-ts")
-    {
-        $p->{end_ts} .= $str;
-    }
-    elsif ($p->current_element() eq "duration")
-    {
-        $p->{duration} .= $str;
-    }
-    elsif ($p->current_element() eq "objective")
-    {
-        if ($p->{objective} eq '')
+        if ($cur_elm eq "start-ts")
         {
-            $p->{objective} .= $str;
+            $p->{start_ts} .= $str;
         }
-        else
+        elsif ($cur_elm eq "end-ts")
         {
-            $p->{objective} .= "\n";
-            $p->{objective} .= $str;
+            $p->{end_ts} .= $str;
         }
-    }
-    elsif ($p->current_element() eq "verdict")
-    {
-        # save the verdict passed directly as tags,
-        # because there might not be a recap in the last tag of the test
-        $p->{verdict} .= $str;
-    }
-    elsif ($p->current_element() eq "artifact")
-    {
-        $p->{artifact} .= $str;
-    }
-    elsif ($p->current_element() eq "msg")
-    {
-        if ($tester_msg_parsed)
+        elsif ($cur_elm eq "duration")
         {
-            # we cannot cache the expectation/verdicts as done above because it contains raw <br> tags
-            # this messes with the parser, which generates a new event every time, preventing us
-            # from accessing the data in the "end" handler
-            $cur_tester_msg .= $str;
+            $p->{duration} .= $str;
+        }
+        elsif ($cur_elm eq "objective")
+        {
+            if ($p->{objective} eq '')
+            {
+                $p->{objective} .= $str;
+            }
+            else
+            {
+                $p->{objective} .= "\n";
+                $p->{objective} .= $str;
+            }
+        }
+        elsif ($cur_elm eq "verdict")
+        {
+            # save the verdict passed directly as tags,
+            # because there might not be a recap in the last tag of the test
+            $p->{verdict} .= $str;
+        }
+        elsif ($cur_elm eq "artifact")
+        {
+            $p->{artifact} .= $str;
+        }
+        elsif ($cur_elm eq "msg")
+        {
+            if ($tester_msg_parsed)
+            {
+                # We cannot cache the expectation/verdicts as done above
+                # because it contains raw <br> tags.
+                #
+                # It messes with the parser, which generates a new event
+                # every time, preventing us from accessing the data in the
+                # "end" handler.
+                $cur_tester_msg .= $str;
+            }
         }
     }
 
@@ -241,6 +526,38 @@ sub get_unix_date
     }
 
     return $unix_date;
+}
+
+sub parse_datetime
+{
+    my $str = $_[0];
+    my $time = str2time($str);
+
+    if ($str =~ /[0-9]\.([0-9]*)$/)
+    {
+        $time = $time + "0.$1";
+    }
+
+    return $time;
+}
+
+sub update_last_time
+{
+    my ($last_time, $new_time) = @_;
+
+    return $new_time if (not $last_time);
+
+    my $last_parsed = parse_datetime($last_time);
+    my $new_parsed = parse_datetime($new_time);
+
+    if ($last_parsed > $new_parsed)
+    {
+        return $last_time;
+    }
+    else
+    {
+        return $new_time;
+    }
 }
 
 sub fix_start
@@ -308,7 +625,7 @@ sub parse_plan
 {
     my $plan = $_[0];
     my $plan_info = from_json($plan);
-    if ($plan_info->{version} == 1)
+    if ($plan_info->{version} >= 1)
     {
         $parsed_data->{plan} = $plan_info->{plan};
     }
@@ -329,7 +646,7 @@ sub handle_end
     elsif ($e eq "duration")
     {
         $cur_iter->{end_ts} = fix_end($cur_iter->{start_ts}, $cur_iter->{end_ts}, $p->{duration});
-        $last_ts = $cur_iter->{end_ts};
+        $last_ts = update_last_time($last_ts, $cur_iter->{end_ts});
         $cur_iter->{start_ts} = fix_start($cur_iter->{start_ts});
         if ($first_ts eq '')
         {
@@ -343,95 +660,55 @@ sub handle_end
     }
     elsif ($e eq "verdict")
     {
-        push(@{$cur_iter->{verdicts}}, $p->{verdict});
+        my $result = $cur_iter->{obtained};
+
+        if (not exists($result->{verdicts}))
+        {
+            $result->{verdicts} = [];
+        }
+
+        push(@{$result->{verdicts}}, $p->{verdict});
     }
     elsif ($e eq "artifact")
     {
-        push(@{$cur_iter->{artifacts}}, $p->{artifact});
+        if ($p->{level} eq "MI")
+        {
+            # MI artifact.
+            if (not exists($cur_iter->{measurements}))
+            {
+                $cur_iter->{measurements} = [];
+            }
+            push(@{$cur_iter->{measurements}}, from_json($p->{artifact}));
+        }
+        else
+        {
+            my $result = $cur_iter->{obtained};
+
+            if (not exists($result->{artifacts}))
+            {
+                $result->{artifacts} = [];
+            }
+
+            push(@{$result->{artifacts}}, $p->{artifact});
+        }
     }
     elsif ($e eq "msg")
     {
         if ($tester_msg_parsed)
         {
-            my $current_data_rope = 0;
-            my $expected_paragraph = 0;
-
             push(@{$tester_msg}, $cur_tester_msg);
 
-            foreach my $s (@{$tester_msg})
+            my ($obtained, $expected) = parse_tester_end_msg($tester_msg);
+
+            if (%$obtained)
             {
-                if ($s ne '')
-                {
-                    if ($s =~ /^\s*Expected results are:\s*(.*)/)
-                    {
-                        if ($1 ne '' and $1 ne "default")
-                        {
-                            $cur_iter->{tag_expression} = $1;
-                        }
-                        $current_data_rope = 1;
-                        $expected_paragraph = 1;
-                    }
-                    elsif ($s =~ /^\s*([A-Z]+) with verdicts:/)
-                    {
-                        if (!$expected_paragraph)
-                        {
-                            # NOTE: the actual result and the verdicts are already parsed from the tag's attribute,
-                            # but we parse the verdicts again because they can be incomplete.
-                            $cur_iter->{verdicts} = [];
-                            $current_data_rope = 2;
-                        }
-                        else
-                        {
-                            $cur_iter->{result_expected} = $1;
-                            $current_data_rope = 3;
-                        }
-                    }
-                    elsif ($s =~ /^\s*Key: (.*)/)
-                    {
-                        $cur_iter->{keys} = $1;
-                        $current_data_rope = 0;
-                    }
-                    elsif ($s =~ /^\s*Artifacts:/)
-                    {
-                        $current_data_rope = 0;
-                    }
-                    elsif ($s =~ /^\s*Notes: (.*)/)
-                    {
-                        $cur_iter->{notes} = $1;
-                        $current_data_rope = 0;
-                    }
-                    elsif ($s =~ /^\s*Obtained result is:/)
-                    {
-                        $current_data_rope = 0;
-                    }
-                    elsif ($current_data_rope > 0)
-                    {
-                        if ($current_data_rope == 1)
-                        {
-                            if ($s =~ /^\s*(default|[A-Z]+)/)
-                            {
-                                $cur_iter->{result_expected} = $1;
-                            }
-                            else
-                            {
-                                $cur_iter->{tag_expression} .= $s;
-                            }
-                        }
-                        else
-                        {
-                            $s =~ s/;\s*$//;
-                            if ($current_data_rope == 2)
-                            {
-                                push(@{$cur_iter->{verdicts}}, $s);
-                            }
-                            elsif ($current_data_rope == 3)
-                            {
-                                push(@{$cur_iter->{verdicts_expected}}, $s);
-                            }
-                        }
-                    }
-                }
+                $cur_iter->{obtained} = $obtained;
             }
+            if (%$expected)
+            {
+                $cur_iter->{expected} = $expected;
+            }
+
             $tester_msg = [];
             $cur_tester_msg = '';
         }
@@ -444,6 +721,7 @@ sub handle_end
 
         pop(@cur_nodes);
 
+        fix_results($cur_iter);
         $parent_iter = pop(@iters_stack);
         push(@{$parent_iter->{iters}}, $cur_iter);
         $cur_iter = $parent_iter;


### PR DESCRIPTION
# Overview of changes

## Importruns
Update XML log parser to generate logs in the new JSON format and adjust JSON log processing accordingly to support the updated structure. Import the run log in JSON format if the corresponding *bublik.json* file is present.

## Run stats / History
Extend data structure for multiple expected results and ensure naming consistency.


# UI Requirements
Changes in the response data structure must be considered for the following requests:
- `GET /bublik/api/v2/results/?parent_id=<parent ID\>&test_name=<test name\>`
- `GET /bublik/api/v2/history/?test_name=<test name\>`

Before:
 ```
 "obtained_result": {
       "result_type": "PASSED",
       "verdict": []
   },
   "expected_result": {
       "result_type": "PASSED",
       "verdict": [],
       "key": []
   },
 ```
 After:
 ```
 "obtained_result": {
     "result_type": "PASSED",
     "verdicts": []
 },
 "expected_results": [
     {
         "result_type": "PASSED",
         "verdicts": [],
         "keys": []
     },
     {
         "result_type": "FAILED",
         "verdicts": [],
         "keys": []
     }
 ],
 ```
