### PR TITLE
History: extend trend charts view data with measurement series chart

### DIFF
--- a/bublik/core/measurement/services.py
+++ b/bublik/core/measurement/services.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
+from itertools import groupby
+
+from django.core.exceptions import ObjectDoesNotExist
+
+from bublik.core.measurement.representation import ChartViewBuilder
 from bublik.data.models import (
     ChartView,
     ChartViewType,
@@ -92,3 +97,66 @@ def get_y_chart_views(line_chart_views):
     return line_chart_views.filter(
         type=ChartViewType.conv(ChartViewType.AXIS_Y),
     )
+
+
+def get_measurement_charts(result_id):
+    views = get_views(result_id)
+    try:
+        # check if there are any views
+        if not views:
+            raise ObjectDoesNotExist
+        # get line-graph charts
+        charts_from_lines = []
+        line_graph_views = get_line_graph_views(views)
+        if line_graph_views:
+            for view in line_graph_views:
+                line_chart_views = get_chart_views(result_id, view)
+                x_chart_view = get_x_chart_view(line_chart_views)
+                y_chart_views = get_y_chart_views(line_chart_views)
+
+                axis_x = get_measurement_result_lists(
+                    x_chart_view.result.id,
+                    x_chart_view.measurement,
+                )
+
+                for y_chart_view in y_chart_views:
+                    axis_y = get_measurement_result_lists(
+                        y_chart_view.result.id,
+                        y_chart_view.measurement,
+                    )
+                    charts_from_lines.append(
+                        ChartViewBuilder(axis_y.measurement, y_chart_view.view)
+                        .by_lines(
+                            axis_y,
+                            axis_x,
+                        )
+                        .representation(),
+                    )
+        # get point charts
+        charts_from_points = []
+        point_views = get_point_views(views)
+        if point_views:
+
+            def grouper_by_measurement(cv):
+                return cv.measurement.id
+
+            for view in point_views:
+                point_chart_views = get_chart_views(result_id, view)
+                point_chart_views = sorted(point_chart_views, key=grouper_by_measurement)
+                for _measurement_id, points in groupby(
+                    point_chart_views,
+                    key=grouper_by_measurement,
+                ):
+                    charts_from_points.append(ChartViewBuilder.by_points(points))
+                    # Make ChartViewBuilder process point chart view as well:
+                    # - init by CV line object | list of CV point objects ->
+                    # -> ChartViewBuilder.by_points(cvs)
+        # get all views charts
+        charts = charts_from_lines + charts_from_points
+    except ObjectDoesNotExist:
+        mmr_lists = get_measurement_result_lists(result_id)
+        charts = [
+            ChartViewBuilder(mmr_list.measurement).by_lines(mmr_list).representation()
+            for mmr_list in mmr_lists
+        ]
+    return charts

--- a/bublik/interfaces/api_v2/measurements.py
+++ b/bublik/interfaces/api_v2/measurements.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
+from collections import OrderedDict
 import typing
 
 from rest_framework import status
@@ -9,9 +10,9 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from bublik.core.measurement.representation import ChartViewBuilder
-from bublik.core.measurement.services import get_measurement_results
-from bublik.core.utils import unordered_group_by
-from bublik.data.models import Measurement
+from bublik.core.measurement.services import get_measurement_charts, get_measurement_results
+from bublik.core.utils import key_value_dict_transforming, unordered_group_by
+from bublik.data.models import Measurement, TestIterationResult
 from bublik.data.serializers import MeasurementSerializer
 
 
@@ -51,6 +52,45 @@ class MeasurementViewSet(GenericViewSet):
                 for _mm_key, mmr_group in mmrs_groups.items()
             ],
         )
+
+    @action(detail=False, methods=['post'])
+    def by_result_ids(self, request):
+        result_ids = request.data.get('result_ids', None)
+        if not result_ids:
+            return Response(
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                data={'type': 'ValueError', 'message': 'No result IDs specified'},
+            )
+
+        measurement_series_charts_by_result = []
+        for result_id in result_ids:
+            test_result = TestIterationResult.objects.get(id=result_id)
+
+            # get parameters
+            parameters = {}
+            for test_argument in test_result.iteration.test_arguments.all():
+                parameters[test_argument.name] = test_argument.value
+            parameters = OrderedDict(sorted(parameters.items()))
+            parameters_list = key_value_dict_transforming(parameters)
+
+            # get chart data
+            measurement_series_charts = []
+            for chart in get_measurement_charts(result_id):
+                chart['id'] = f'{test_result.id}_{chart["id"]}'
+                measurement_series_charts.append(chart)
+
+            measurement_series_charts_by_result.append(
+                {
+                    'run_id': test_result.test_run_id,
+                    'result_id': test_result.id,
+                    'start': test_result.start,
+                    'test_name': test_result.iteration.test.name,
+                    'parameters_list': parameters_list,
+                    'measurement_series_charts': measurement_series_charts,
+                },
+            )
+
+        return Response(measurement_series_charts_by_result)
 
     def retrieve(self, request, pk=None):
         measurement = self.get_object()

--- a/bublik/interfaces/api_v2/measurements.py
+++ b/bublik/interfaces/api_v2/measurements.py
@@ -30,7 +30,7 @@ class MeasurementViewSet(GenericViewSet):
         return Response(serializer.data)
 
     @action(detail=False, methods=['post'])
-    def by_result_ids(self, request):
+    def trend_charts(self, request):
         result_ids = request.data.get('result_ids', None)
         if not result_ids:
             return Response(


### PR DESCRIPTION
# Info
Added API for per-result measurement series to enable stacked chart rendering in the UI.

# Issues
Related to #113 

# UI Requirements
Trend chart data is now available via request `GET /bublik/api/v2/measurements/trend_charts/` instead of request `GET /bublik/api/v2/measurements/by_result_ids/`.
Request `GET /bublik/api/v2/measurements/by_result_ids/` can be used to retrieve data for per-result measurement series charts:
```
[
    {
        "run_id": 1,
        "result_id": 336,
        "start": "2025-05-31T05:49:21.675000Z",
        "test_name": "ws_one_thread",
        "parameters_list": [
            "env=VAR.env.peer2peer",
            "latency_interval=1",
            "profile=none",
            "send_rate=1000",
            "send_size=300"
        ],
        "measurement_series_charts": [
            {
                "id": "336_858",
                "title": "rtt, ns",
                "subtitle": "Latency (seconds, single): based on trade_server",
                "axis_x": {
                    "label": "time (seconds)",
                    "key": "time (seconds)"
                },
                "axis_y": {
                    "label": "rtt (seconds)",
                    "key": "rtt (seconds)"
                },
                "dataset": [
                    [
                        "time (seconds)",
                        "rtt (seconds)"
                    ],
                    [
                        0.000999125,
                        37089
                    ],
                    [
                        0.00200785,
                        36844
                    ],
                    [
                        0.00301635,
                        35945
                    ],
                    [
                        0.00402639,
                        36905
                    ],
                    [
                        0.00503635,
                        37905
                    ],
                    [
                        0.00604412,
                        36852
                    ],
                    [
                        0.00705328,
                        37330
                    ],
                    [
                        0.00806192,
                        36862
                    ]
                ]
            }
        ]
    },
    {
        "run_id": 1,
        "result_id": 343,
        "start": "2025-05-31T05:53:20.422000Z",
        "test_name": "ws_one_thread",
        "parameters_list": [
            "env=VAR.env.peer2peer",
            "latency_interval=1",
            "profile=websockets",
            "send_rate=1000",
            "send_size=300"
        ],
        "measurement_series_charts": [
            {
                "id": "343_858",
                "title": "rtt, ns",
                "subtitle": "Latency (seconds, single): based on trade_server",
                "axis_x": {
                    "label": "time (seconds)",
                    "key": "time (seconds)"
                },
                "axis_y": {
                    "label": "rtt (seconds)",
                    "key": "rtt (seconds)"
                },
                "dataset": [
                    [
                        "time (seconds)",
                        "rtt (seconds)"
                    ],
                    [
                        0.00100109,
                        35942
                    ],
                    [
                        0.00201056,
                        35273
                    ],
                    [
                        0.00302062,
                        35168
                    ],
                    [
                        0.00403086,
                        35643
                    ],
                    [
                        0.00504105,
                        36013
                    ],
                    [
                        0.00605106,
                        36030
                    ],
                    [
                        0.00705925,
                        34473
                    ],
                    [
                        0.00806887,
                        34585
                    ]
                ]
            }
        ]
    }
]
```