### PR TITLE
ci: exclude migrations from code quality checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ jobs:
         with:
           files: |
             **/*.py
+          files_ignore: |
+            bublik/data/migrations/**
 
   format-check:
     name: Check Code Formatting


### PR DESCRIPTION
Auto-generated migration files don't need to follow code style guidelines