### PR TITLE
auth: resolve invalid refresh flow due to premature access token validation

### DIFF
--- a/bublik/interfaces/api_v2/auth.py
+++ b/bublik/interfaces/api_v2/auth.py
@@ -19,7 +19,11 @@ from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
-from bublik.core.auth import auth_required, get_user_by_access_token, get_user_info_from_access_token
+from bublik.core.auth import (
+    auth_required,
+    get_user_by_access_token,
+    get_user_info_from_access_token,
+)
 from bublik.core.mail import EmailVerificationTokenGenerator, send_verification_link_mail
 from bublik.core.shortcuts import build_absolute_uri
 from bublik.data.models import User
@@ -34,14 +38,14 @@ from bublik.data.serializers import (
 
 
 __all__ = [
-    'RegisterView',
+    'AdminViewSet',
+    'ForgotPasswordResetView',
+    'ForgotPasswordView',
     'LogInView',
+    'LogOutView',
     'ProfileViewSet',
     'RefreshTokenView',
-    'LogOutView',
-    'ForgotPasswordView',
-    'ForgotPasswordResetView',
-    'AdminViewSet',
+    'RegisterView',
 ]
 
 


### PR DESCRIPTION
`RefreshTokenView` was attempting to decode and validate a newly
generated access token immediately after deriving it from the refresh
token. Since this access token was not yet persisted and blacklisting
checks rely on existing claims, validation always failed, resulting in
`Not Authenticated` message

Changes:
- Resolve user directly from the refresh token payload `user_id`
- Old refresh token is blacklisted
- New tokens are issued without unnecessary validation of not active
access token