### PR TITLE
Importruns: bugfix

### DIFF
--- a/bublik/core/importruns/live/context.py
+++ b/bublik/core/importruns/live/context.py
@@ -185,6 +185,7 @@ class LiveLogContext:
                 meta_data = MetaData(data['meta_data'])
                 self.run = identify_run(meta_data.key_metas)
                 self.last_ts = meta_data.run_start
+                self.project_id = meta_data.project_id
             except Exception as e:
                 err = e if isinstance(e, str) else 'error occurred while processing metadata'
                 raise LLInternalError(err) from err
@@ -194,7 +195,11 @@ class LiveLogContext:
 
         force_update = True
         if self.run is None:
-            run_data = {'test_run': None, 'start': meta_data.run_start}
+            run_data = {
+                'test_run': None,
+                'start': meta_data.run_start,
+                'project_id': self.project_id,
+            }
             self.run = TestIterationResult.objects.create(**run_data)
             force_update = False
         else:
@@ -333,7 +338,7 @@ class LiveLogContext:
             test_iteration = add_iteration(test, None, '', parent_iter, len(self.test_stack))
             # Create TestIterationResult
             test_iteration_result = add_iteration_result(
-                project_id=None,
+                project_id=self.project_id,
                 start_time=self.last_ts,
                 iteration=test_iteration,
                 run=self.run,

--- a/bublik/core/importruns/source/execution.py
+++ b/bublik/core/importruns/source/execution.py
@@ -277,9 +277,10 @@ def incremental_import(run_log, project_id, meta_data, run_completed, force):
 
     logger.info('the process of adding tags is started')
     start_time = datetime.now()
-    add_tags(run, run_log.get('tags'))
+    tags = run_log.get('tags', [])
+    add_tags(run, tags)
     logger.info(f'the process of adding tags is completed in [{datetime.now() - start_time}]')
-    logger.info(f"the number of added tags is {len(run_log.get('tags'))}")
+    logger.info(f'the number of added tags is {len(tags)}')
 
     call_command('run_cache', 'delete', '-i', run.id, '--logger_out', True)
 

--- a/bublik/core/run/metadata.py
+++ b/bublik/core/run/metadata.py
@@ -94,28 +94,28 @@ class MetaData:
         # Check metadata version
         self.version = meta_data.get('version')
         if not self.version or (self.version and self.version > 1):
-            logger.error('not valid version of meta_data.json')
-            raise ValueError
+            msg = 'not valid version of meta_data.json'
+            raise ValueError(msg)
 
         # Check format specific data
         self.metas = meta_data.get('metas')
         if not self.metas:
-            logger.error('meta_data.json parser expected a list of metas')
-            raise KeyError
+            msg = 'meta_data.json parser expected a list of metas'
+            raise KeyError(msg)
 
         # Check and safe project meta ID
         project_meta = find_dict_in_list({'name': 'PROJECT'}, self.metas)
         if not project_meta:
-            logger.error('meta_data.json parser expected a PROJECT meta.')
-            raise ValueError
+            msg = 'meta_data.json parser expected a PROJECT meta.'
+            raise ValueError(msg)
         try:
             self.project_id = Project.objects.get(name=project_meta['value']).id
         except Project.DoesNotExist as mdne:
-            logger.error(
+            msg = (
                 f'The project does not exist: {project_meta["value"]}. '
-                'Create it to import logs.',
+                'Create it to import logs.'
             )
-            raise ObjectDoesNotExist from mdne
+            raise ObjectDoesNotExist(msg) from mdne
 
         # Check status meta
         run_status_meta = ConfigServices.getattr_from_global(
@@ -124,8 +124,8 @@ class MetaData:
             self.project_id,
         )
         if not find_dict_in_list({'name': run_status_meta}, self.metas):
-            logger.error('There is no status meta in meta_data.json. It is a required meta.')
-            raise ValueError
+            msg = 'There is no status meta in meta_data.json. It is a required meta.'
+            raise ValueError(msg)
 
         key_metas_fields = set()
         key_metas_names = ConfigServices.getattr_from_global(
@@ -160,25 +160,25 @@ class MetaData:
 
             # Check key metas duplicates
             elif find_dict_in_list({'name': meta_name}, self.key_metas):
-                logger.error(
+                msg = (
                     f'the following key meta is duplicated: {meta_name}, '
-                    'that compromises metadata, ignoring the run',
+                    'that compromises metadata, ignoring the run'
                 )
-                raise ValueError
+                raise ValueError(msg)
 
         if key_metas_names:
-            logger.error(
+            msg = (
                 "can't identify the run, the following RUN_KEY_METAS are "
-                f"absent in metadata: {','.join(key_metas_names)}",
+                f"absent in metadata: {','.join(key_metas_names)}"
             )
-            raise AttributeError
+            raise AttributeError(msg)
 
         # Check if all key metas satisfy Meta model
         model_fields = [f.name for f in Meta._meta.get_fields()]
         diff = get_difference(key_metas_fields, model_fields)
         if diff:
-            logger.error(f"meta can't have the following fields: {','.join(diff)}")
-            raise ValueError
+            msg = f"meta can't have the following fields: {','.join(diff)}"
+            raise ValueError(msg)
 
     def __parse_timestamps(self):
         start_meta = find_dict_in_list({'name': 'START_TIMESTAMP'}, self.metas)

--- a/bublik/interfaces/management/commands/importruns.py
+++ b/bublik/interfaces/management/commands/importruns.py
@@ -177,15 +177,17 @@ class Command(BaseCommand):
                 'log.xml.xz',
                 'raw_log_bundle.tpxz',
             ]
-            for log_file in log_files:
-                if save_url_to_dir(run_url, process_dir, log_file):
-                    if log_file == 'bublik.json':
-                        json_data = JSONLog().convert_from_dir(process_dir, log_file)
-                    else:
-                        json_data = JSONLog().convert_from_dir(process_dir)
-                    url_str = os.path.join(run_url, log_file)
-                    logger.info(f'run logs were downloaded from {url_str}')
-                    break
+            log_file = next(
+                (f for f in log_files if save_url_to_dir(run_url, process_dir, f)),
+                None,
+            )
+            if log_file:
+                args = (process_dir, log_file) if log_file == 'bublik.json' else (process_dir,)
+                json_data = JSONLog().convert_from_dir(*args)
+                logger.info(f'run logs were downloaded from {os.path.join(run_url, log_file)}')
+            else:
+                json_data = None
+                logger.warning('no logs were downloaded')
 
             if meta_data_saved:
                 # Load meta_data.json


### PR DESCRIPTION
Done:
1. Prevent import failures when logs are missing
2. Prevent import failures when tags are missing
3. Link runs to projects in live import to fix errors in displaying running sessions and to prevent sessions from being unassociated with a project
4. Include metadata validation error messages in error events
