### PR TITLE
Requirements: update packages versions to pick up bug fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ chardet==3.0.4
 click==8.1.2
 coverage==5.3
 cryptography==44.0.1
-deepdiff==6.2.3
+deepdiff==8.6.1
 Dickens==2.0.0
 django-admin==1.3.2
 django-bulk-update==2.2.0
@@ -32,7 +32,7 @@ django-lint==2.0.4
 django-redis-cache==3.0.1
 django-six==1.0.4
 django-static-jquery==2.1.4
-Django==5.1.7
+Django==5.1.10
 djangorestframework-simplejwt
 djangorestframework==3.15.2
 drf-spectacular-sidecar==2024.11.1
@@ -86,7 +86,7 @@ pytzdata==2020.1
 PyYAML==6.0.1
 redis==3.5.3
 requests-kerberos==0.15.0
-requests==2.32.3
+requests==2.32.4
 ruff
 screen==1.0.1
 shell==1.0.1
@@ -97,11 +97,11 @@ SQLAlchemy==2.0.36
 sqlparse==0.5.1
 toml==0.10.2
 tomli
-tornado==6.4.2
+tornado==6.5.2
 treelib==1.6.1
 typed-ast==1.5.5
 unify==0.5
-urllib3==2.2.2
+urllib3==2.5.0
 vine==5.1.0
 xlwt==1.3.0
 XStatic-Patternfly-Bootstrap-Treeview==2.1.3.2


### PR DESCRIPTION
Upgrade dependencies:
 - DeepDiff -> 8.6.1
 - Django -> 5.1.10
 - Requests -> 2.32.4
 - Tornado -> 6.5.2
 - urllib3 -> 2.5.0