### PR TITLE
Config: enable dashboard navigation by default

### DIFF
--- a/bublik/data/schemas/per_conf.json
+++ b/bublik/data/schemas/per_conf.json
@@ -63,6 +63,11 @@
                 "items": {
                     "type": "string"
                 }
+            },
+            "default": {
+                "total": "go_tree",
+                "unexpected": "go_run_failed",
+                "notes": "go_bug"
             }
         },
         "DASHBOARD_DATE": {


### PR DESCRIPTION
Extend the main configuration schema with a default value for DASHBOARD_PAYLOAD so that it is included in the generated default configuration.