### PR TITLE
Run data: add configuration to run details

### DIFF
--- a/bublik/core/meta/categorization.py
+++ b/bublik/core/meta/categorization.py
@@ -55,8 +55,11 @@ def group_by_runs_and_category(metas, categories, format_fn=key_value_list_trans
     for result_id, metas_and_categories in dicts_groupby(metas, dict_key='result_id'):
         metas_by_category[result_id] = OrderedDict.fromkeys(categories, [])
         # Group by category
-        for category, metas in dicts_groupby(metas_and_categories, dict_key='category'):
-            metas_group = list(format_fn(metas)) if format_fn else metas
+        for category, category_metas in dicts_groupby(
+            metas_and_categories,
+            dict_key='category',
+        ):
+            metas_group = list(format_fn(category_metas)) if format_fn else category_metas
             metas_by_category[result_id][category] = metas_group
     return metas_by_category
 

--- a/bublik/core/run/stats.py
+++ b/bublik/core/run/stats.py
@@ -659,6 +659,13 @@ def generate_all_run_details(run):
     branches = q.metas_query('branch')
     revisions = build_revision_references(q.metas_query('revision'), project.id)
     labels = q.labels_query(category_names, project.id)
+    configurations = list(
+        key_value_list_transforming(
+            get_metas_by_category(run_meta_results, ['Configuration'], project.id)[
+                'Configuration'
+            ],
+        ),
+    )
     categories = get_metas_by_category(run_meta_results, category_names, project.id)
     for category, category_values in categories.items():
         categories[category] = key_value_list_transforming(category_values)
@@ -683,6 +690,7 @@ def generate_all_run_details(run):
         'revisions': revisions,
         'labels': key_value_list_transforming(labels),
         'special_categories': categories,
+        'configuration': configurations[0] if configurations else None,
     }
 
 


### PR DESCRIPTION
# Overview of changes

## API

### GET /bublik/api/v2/runs/{run ID}/details/
The response data now contains the configuration key:
```
{
    "project_id": 1,
    "project_name": "dpdk-ethdev-ts",
    ....
    "special_categories": {
        "Configuration": [
            "galdor-x710-p0"
        ]
    },
    "configuration": "galdor-x710-p0"
}
```

# Issues
Closes: #205