### PR TITLE
Server: fix incorrect inheritance causing queryset assertion

### DIFF
--- a/bublik/interfaces/api_v2/server.py
+++ b/bublik/interfaces/api_v2/server.py
@@ -5,9 +5,8 @@ import typing
 
 from django.conf import settings
 from rest_framework.decorators import action
-from rest_framework.mixins import RetrieveModelMixin
 from rest_framework.response import Response
-from rest_framework.viewsets import GenericViewSet
+from rest_framework.viewsets import ViewSet
 
 from bublik.core.config.services import ConfigServices
 from bublik.data.models import GlobalConfigs
@@ -18,7 +17,7 @@ __all__ = [
 ]
 
 
-class ServerViewSet(RetrieveModelMixin, GenericViewSet):
+class ServerViewSet(ViewSet):
     filter_backends: typing.ClassVar['list'] = []
 
     @action(detail=False, methods=['get'])


### PR DESCRIPTION
Inheriting from model mixins in ServerViewSet causes an assertion error because no queryset is defined. Since ServerViewSet is not model-based, its base classes were replaced with the non-model ViewSet to avoid this error.