### PR TITLE
Importruns: fix project handling during live import

### DIFF
--- a/bublik/core/importruns/live/context.py
+++ b/bublik/core/importruns/live/context.py
@@ -185,7 +185,7 @@ class LiveLogContext:
                 meta_data = MetaData(data['meta_data'])
                 self.run = identify_run(meta_data.key_metas)
                 self.last_ts = meta_data.run_start
-                self.project_id = meta_data.project_id
+                self.project = meta_data.project
             except Exception as e:
                 err = e if isinstance(e, str) else 'error occurred while processing metadata'
                 raise LLInternalError(err) from err
@@ -198,7 +198,7 @@ class LiveLogContext:
             run_data = {
                 'test_run': None,
                 'start': meta_data.run_start,
-                'project_id': self.project_id,
+                'project_id': self.project.id,
             }
             self.run = TestIterationResult.objects.create(**run_data)
             force_update = False
@@ -338,7 +338,7 @@ class LiveLogContext:
             test_iteration = add_iteration(test, None, '', parent_iter, len(self.test_stack))
             # Create TestIterationResult
             test_iteration_result = add_iteration_result(
-                project_id=self.project_id,
+                project_id=self.project.id,
                 start_time=self.last_ts,
                 iteration=test_iteration,
                 run=self.run,

--- a/bublik/core/run/metadata.py
+++ b/bublik/core/run/metadata.py
@@ -45,7 +45,7 @@ class MetaData:
 
     FMT_META_DATA_GENERATE = '{path_meta_data_script} --path {process_dir} --project {project}'
 
-    def __init__(self, meta_data_json, project):
+    def __init__(self, meta_data_json, project=None):
         super().__init__()
         self.project = project
         self.version = None


### PR DESCRIPTION
The MetaData attribute now stores the project object itself rather than its identifier, which must be taken into account when using MetaData during live import. In addition, since the project argument is not available during live import, a default project value must be added.