### PR TITLE
Results: fix inconsistent return type when retrieving tests by name

### DIFF
--- a/bublik/core/run/tests_organization.py
+++ b/bublik/core/run/tests_organization.py
@@ -70,15 +70,20 @@ def get_test_by_full_path(full_test_name):
         return None
 
 
-def get_tests_by_name(test_name):
+def get_test_ids_by_name(test_name):
     if test_name.startswith('../') or '/' not in test_name:
         # In some projects ../ is a valid part of a test name.
         test_entity = models.ResultType.conv('test')
-        return models.Test.objects.filter(name=test_name, result_type=test_entity)
+        return list(
+            models.Test.objects.filter(name=test_name, result_type=test_entity).values_list(
+                'id',
+                flat=True,
+            ),
+        )
     test = get_test_by_full_path(test_name)
     if not test:
         return []
-    return [test]
+    return [test.id]
 
 
 def prepare_package_data(package, parents_str):

--- a/bublik/interfaces/api_v2/history.py
+++ b/bublik/interfaces/api_v2/history.py
@@ -30,7 +30,7 @@ from bublik.core.run.data import (
     get_verdicts,
 )
 from bublik.core.run.filter_expression import filter_by_expression
-from bublik.core.run.tests_organization import get_tests_by_name
+from bublik.core.run.tests_organization import get_test_ids_by_name
 from bublik.core.run.utils import prepare_dates_period
 from bublik.data.models import (
     MeasurementResult,
@@ -100,8 +100,8 @@ class HistoryViewSet(ListModelMixin, GenericViewSet):
         result_types = self.request.query_params.get('result_types', '')
 
         # Check passed test name first
-        tests = get_tests_by_name(test_name)
-        if not tests:
+        test_ids = get_test_ids_by_name(test_name)
+        if not test_ids:
             raise ValidationError(detail='Invalid test name', code=status.HTTP_404_NOT_FOUND)
 
         ### Apply run filters ###
@@ -157,7 +157,6 @@ class HistoryViewSet(ListModelMixin, GenericViewSet):
         ### Apply iteration filters ###
 
         # Filter test iterations by test name
-        test_ids = list(tests.values_list('id', flat=True))
         test_iterations = TestIteration.objects.filter(test__in=test_ids)
 
         # Filter test iterations by hash

--- a/bublik/interfaces/api_v2/results.py
+++ b/bublik/interfaces/api_v2/results.py
@@ -35,7 +35,7 @@ from bublik.core.run.stats import (
     get_run_stats_detailed_with_comments,
     get_run_status,
 )
-from bublik.core.run.tests_organization import get_tests_by_name
+from bublik.core.run.tests_organization import get_test_ids_by_name
 from bublik.core.utils import get_difference
 from bublik.data import models
 from bublik.data.serializers import TestIterationResultSerializer
@@ -217,10 +217,10 @@ class ResultViewSet(ModelViewSet):
             queries &= Q(parent_package=parent_id)
 
         if test_name:
-            tests = get_tests_by_name(test_name)
-            if not tests:
+            test_ids = get_test_ids_by_name(test_name)
+            if not test_ids:
                 errors.append('No tests found by the given test name')
-            queries &= Q(iteration__test__in=tests, iteration__hash__isnull=False)
+            queries &= Q(iteration__test__in=test_ids, iteration__hash__isnull=False)
 
         if results:
             results = results.split(query_delimiter)


### PR DESCRIPTION
Return a list of IDs when retrieving tests by name to fix an error occurring in history when a test path is passed as the test name.