### PR TITLE
Config: update schemas, fix paginations

### DIFF
--- a/bublik/interfaces/api_v2/__init__.py
+++ b/bublik/interfaces/api_v2/__init__.py
@@ -13,7 +13,7 @@ from .auth import (
     RegisterView,
 )
 from .comments import TestCommentViewSet
-from .config import ConfigViewSet
+from .config.views import ConfigViewSet
 from .dashboard import (
     DashboardPayload,
     DashboardViewSet,

--- a/bublik/interfaces/api_v2/config.py
+++ b/bublik/interfaces/api_v2/config.py
@@ -23,6 +23,7 @@ from bublik.data.serializers import ConfigSerializer
 
 
 class ConfigViewSet(ModelViewSet):
+    pagination_class = None
     queryset = Config.objects.all()
     serializer_class = ConfigSerializer
     filterset_class = ConfigFilter

--- a/bublik/interfaces/api_v2/config.py
+++ b/bublik/interfaces/api_v2/config.py
@@ -237,9 +237,9 @@ class ConfigViewSet(ModelViewSet):
         Of all configurations having the same project, type and name, if there are active ones,
         returns active ones, if there are none, returns the latest ones.
         '''
+        queryset = self.filter_queryset(self.get_queryset())
         configs_to_display = (
-            self.get_queryset()
-            .order_by('project', 'type', 'name', '-is_active', '-created')
+            queryset.order_by('project', 'type', 'name', '-is_active', '-created')
             .distinct('project', 'type', 'name')
             .values(
                 'id',
@@ -252,4 +252,4 @@ class ConfigViewSet(ModelViewSet):
                 'created',
             )
         )
-        return Response(configs_to_display)
+        return Response(list(configs_to_display))

--- a/bublik/interfaces/api_v2/config/schemas.py
+++ b/bublik/interfaces/api_v2/config/schemas.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+)
+
+from bublik.data.serializers import ConfigSerializer
+from bublik.interfaces.api_v2.config.serializers import (
+    AllVersionsResponseSerializer,
+    AvailableTypesNamesResponseSerializer,
+    ConfigListResponseSerializer,
+    ConfigPartialUpdateRequestSerializer,
+)
+from bublik.interfaces.api_v2.errors.serializers import ErrorResponseSerializer
+
+
+config_viewset_schema = extend_schema_view(
+    list=extend_schema(
+        summary='List of configurations',
+        description='''
+        Returns a list of configurations.
+        Of all configurations having the same project, type and name:
+        - If there are active ones, returns active ones
+        - If there are none, returns the latest ones
+        ''',
+        responses={
+            200: OpenApiResponse(
+                response=ConfigListResponseSerializer,
+                description='Configurations were successfully retrieved',
+            ),
+        },
+        tags=['Configuration'],
+    ),
+    create=extend_schema(
+        summary='Creates new configuration',
+        description='''
+        Creates new configuration. Requires administrator's role.
+        ''',
+        request=ConfigSerializer,
+        responses={
+            201: OpenApiResponse(
+                response=ConfigSerializer,
+                description='Configuration was successfully created',
+            ),
+            400: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Invalid configuration data was provided',
+            ),
+            403: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Administrator privileges are required to create configurations',
+            ),
+        },
+        tags=['Configuration'],
+    ),
+    partial_update=extend_schema(
+        summary='Partial update configuration',
+        description='''
+        Updates a configuration or creates a new version.
+        Requires administrator's role.
+        ''',
+        request=ConfigPartialUpdateRequestSerializer,
+        responses={
+            200: OpenApiResponse(
+                response=ConfigSerializer,
+                description='Configuration was successfully updated',
+            ),
+            201: OpenApiResponse(
+                response=ConfigSerializer,
+                description='A new configuration version was successfully created',
+            ),
+            400: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Invalid configuration update data was provided',
+            ),
+            403: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Administrator privileges are required to update configurations',
+            ),
+        },
+        tags=['Configuration'],
+    ),
+    destroy=extend_schema(
+        summary='Deletes configuration',
+        description='''
+        Deletes a configuration. Requires administrator's role.
+        ''',
+        responses={
+            204: OpenApiResponse(
+                description='Configuration was successfully deleted',
+            ),
+            403: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Administrator privileges are required to delete configurations',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Configuration was not found',
+            ),
+        },
+        tags=['Configuration'],
+    ),
+    get_schema=extend_schema(
+        summary='Retrieves configuration schema',
+        description='''
+        Retrieves the JSON schema by passed config type and name.
+        ''',
+        parameters=[
+            OpenApiParameter(
+                name='type',
+                type=str,
+                location=OpenApiParameter.QUERY,
+                required=True,
+            ),
+            OpenApiParameter(
+                name='name',
+                type=str,
+                location=OpenApiParameter.QUERY,
+                required=True,
+            ),
+        ],
+        responses={
+            200: OpenApiResponse(
+                response=OpenApiTypes.OBJECT,
+                description='JSON schema was successfully retrieved',
+                examples=[
+                    OpenApiExample(
+                        name='Generic JSON Schema',
+                        summary='Structure of the returned JSON Schema',
+                        value={
+                            '$schema': 'http://json-schema.org/draft-07/schema#',
+                            'type': 'object',
+                            'description': 'Description of the requested configuration schema',
+                            'properties': {
+                                'field_name_1': {
+                                    'description': 'Description of the first setting',
+                                    'type': 'string',
+                                    'default': 'some_value',
+                                },
+                                'field_name_2': {
+                                    'description': 'Description of the second setting',
+                                    'type': 'integer',
+                                    'minimum': 0,
+                                },
+                                'nested_object': {
+                                    'type': 'object',
+                                    'properties': {'sub_field': {'type': 'boolean'}},
+                                },
+                            },
+                            'required': ['field_name_1'],
+                            'additionalProperties': False,
+                        },
+                    ),
+                ],
+            ),
+            422: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='The requested configuration schema could not be retrieved',
+            ),
+        },
+        tags=['Configuration'],
+    ),
+    all_versions=extend_schema(
+        summary='All versions of configuration',
+        description='''
+        Retrieves all versions of passed configurations.
+        ''',
+        responses={
+            200: OpenApiResponse(
+                response=AllVersionsResponseSerializer,
+                description='All versions were successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='No configurations found matching the given parameters',
+            ),
+        },
+        tags=['Configuration'],
+    ),
+    available_types_names=extend_schema(
+        summary='Available configuration types and names',
+        description='''
+        Returns a reference list of all configuration types and names.
+        ''',
+        responses={
+            200: OpenApiResponse(
+                response=AvailableTypesNamesResponseSerializer,
+                description='Available configuration types, names were successfully retrieved',
+            ),
+        },
+        tags=['Configuration'],
+    ),
+)

--- a/bublik/interfaces/api_v2/config/serializers.py
+++ b/bublik/interfaces/api_v2/config/serializers.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+from rest_framework import serializers
+
+
+class ConfigListResponseSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    version = serializers.IntegerField()
+    is_active = serializers.BooleanField()
+    type = serializers.CharField()
+    name = serializers.CharField()
+    description = serializers.CharField(allow_null=True)
+    project = serializers.IntegerField(allow_null=True)
+    created = serializers.DateTimeField()
+
+
+class ConfigVersionSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    version = serializers.IntegerField()
+    is_active = serializers.BooleanField()
+    description = serializers.CharField(allow_null=True)
+    created = serializers.DateTimeField()
+
+
+class AllVersionsResponseSerializer(serializers.Serializer):
+    type = serializers.CharField()
+    name = serializers.CharField()
+    project = serializers.IntegerField(allow_null=True)
+    all_config_versions = ConfigVersionSerializer(many=True)
+
+
+class ConfigTypeNameSerializer(serializers.Serializer):
+    type = serializers.CharField()
+    name = serializers.CharField(required=False)
+    required = serializers.BooleanField()
+    description = serializers.CharField()
+
+
+class AvailableTypesNamesResponseSerializer(serializers.Serializer):
+    config_types_names = ConfigTypeNameSerializer(many=True)
+
+
+class ConfigPartialUpdateRequestSerializer(serializers.Serializer):
+    name = serializers.CharField(required=False)
+    is_active = serializers.BooleanField(required=False)
+    description = serializers.CharField(required=False, allow_null=True)
+    content = serializers.JSONField(required=False)

--- a/bublik/interfaces/api_v2/config/views.py
+++ b/bublik/interfaces/api_v2/config/views.py
@@ -20,9 +20,15 @@ from bublik.core.filter_backends import ProjectFilterBackend
 from bublik.core.shortcuts import serialize
 from bublik.data.models import Config, ConfigTypes, GlobalConfigs, Project, UserRoles
 from bublik.data.serializers import ConfigSerializer
+from bublik.interfaces.api_v2.config.schemas import config_viewset_schema
 
 
+@config_viewset_schema
 class ConfigViewSet(ModelViewSet):
+    '''
+    API for managing system configurations.
+    '''
+
     pagination_class = None
     queryset = Config.objects.all()
     serializer_class = ConfigSerializer
@@ -72,10 +78,6 @@ class ConfigViewSet(ModelViewSet):
 
     @auth_required(as_admin=True)
     def create(self, request, *args, **kwargs):
-        '''
-        Create and return a config unless another with the same name exists.
-        Request: POST api/v2/config.
-        '''
         access_token = request.COOKIES.get('access_token')
         serializer = serialize(
             self.serializer_class,
@@ -88,20 +90,6 @@ class ConfigViewSet(ModelViewSet):
 
     @auth_required(as_admin=True)
     def partial_update(self, request, *args, **kwargs):
-        '''
-        Update a configuration or create a new version.
-
-        Rules:
-        - If name is provided, the configuration and all its versions
-          are renamed.
-        - If content is not provided and description and/or is_active are provided,
-          the configuration is updated accordingly.
-        - If content is provided:
-            - and no version with the same content exists, a new version is created.
-            - and a version with the same content exists, the existing configuration is updated.
-
-        Request: PATCH api/v2/config/<ID>.
-        '''
         config = self.get_object()
 
         with transaction.atomic():
@@ -167,10 +155,6 @@ class ConfigViewSet(ModelViewSet):
 
     @action(detail=False, methods=['get'], url_path='schema')
     def get_schema(self, request, *args, **kwargs):
-        '''
-        Get the JSON schema by passed config type and name.
-        Request: GET api/v2/config/get_schema/?type=<config_type>&name=<config_name>.
-        '''
         config_type = request.query_params.get('type')
         config_name = request.query_params.get('name')
         json_schema = ConfigServices.get_schema(config_type, config_name)
@@ -184,10 +168,6 @@ class ConfigViewSet(ModelViewSet):
 
     @action(detail=True, methods=['get'])
     def all_versions(self, request, *args, **kwargs):
-        '''
-        Get all versions of passed config.
-        Request: GET api/v2/config/<ID>/all_versions.
-        '''
         config = self.get_object()
         config_data = self.get_serializer(config).data
         all_config_versions = Config.objects.get_all_versions(
@@ -206,9 +186,6 @@ class ConfigViewSet(ModelViewSet):
 
     @action(detail=False, methods=['get'])
     def available_types_names(self, request):
-        '''
-        Returns a list of available configuration types and names.
-        '''
         config_type_names = [
             {
                 'type': ConfigTypes.REPORT,
@@ -233,10 +210,6 @@ class ConfigViewSet(ModelViewSet):
         return Response({'config_types_names': config_type_names})
 
     def list(self, request):
-        '''
-        Of all configurations having the same project, type and name, if there are active ones,
-        returns active ones, if there are none, returns the latest ones.
-        '''
         queryset = self.filter_queryset(self.get_queryset())
         configs_to_display = (
             queryset.order_by('project', 'type', 'name', '-is_active', '-created')


### PR DESCRIPTION
This PR introduces a set of improvements and refactors to the configuration system, focusing on schema cleanup, standardization of documentation and paginations fix. Key changes include:

      - Add extend_schema for basic method
      
      - Standardize API documentation structure
      
      - Improve parameter descriptions and examples
      
      - Ensure all endpoints are properly tagged under 'Configuration'
      
      - Add error response schemas for consistency

      - Remove unhandled paginations