### PR TITLE
Requirements: update packages versions to pick up bug fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,14 +23,14 @@ cryptography==44.0.1
 deepdiff==8.6.1
 Dickens==2.0.0
 django-bulk-update==2.2.0
-django-cachalot==2.7.0
+django-cachalot==2.8.0
 django-debug-toolbar==5.0.1
 django-extensions==3.1.5
 django-filter==25.1
 django-redis-cache==3.0.1
 django-six==1.0.4
 django-static-jquery==2.1.4
-Django==5.1.13
+Django==5.2.8
 djangorestframework-simplejwt
 djangorestframework==3.15.2
 drf-spectacular-sidecar==2024.11.1


### PR DESCRIPTION
Upgrade Django to version 5.2.8 and django-cachalot to version 2.8.0.