### PR TITLE
Signals: fix meta categorization call on config change

### DIFF
--- a/bublik/interfaces/signals.py
+++ b/bublik/interfaces/signals.py
@@ -56,7 +56,7 @@ def categorize_metas_on_config_change(sender, instance, **kwargs):
         and instance.is_active
     ):
         project_name = instance.project.name if instance.project else None
-        call_command('meta_categorization', project=project_name)
+        call_command('meta_categorization', project_name=project_name)
 
 
 @receiver(post_delete, sender=MetaTest)


### PR DESCRIPTION
Fix meta categorization command call on active meta config update: use correct argument name for project.