### PR TITLE
API: simplify responses by removing redundant 200 status codes

### DIFF
--- a/bublik/interfaces/api_v2/auth.py
+++ b/bublik/interfaces/api_v2/auth.py
@@ -61,7 +61,6 @@ class RegisterView(generics.CreateAPIView):
         send_verification_link_mail(request, user)
         return Response(
             {'message': 'A verification link has been sent to your email address'},
-            status=status.HTTP_200_OK,
         )
 
 
@@ -82,7 +81,6 @@ class ActivateView(APIView):
             user.save()
             return Response(
                 {'message': 'The email is verified. You are registered.'},
-                status=status.HTTP_200_OK,
             )
         return Response(
             {'message': 'Invalid email verification link'},
@@ -135,7 +133,6 @@ class LogInView(TokenObtainPairView):
         response.data = {
             'user': UserSerializer(user).data,
         }
-        response.status_code = status.HTTP_200_OK
         return response
 
 
@@ -154,7 +151,7 @@ class ProfileViewSet(GenericViewSet):
         access_token = request.COOKIES.get('access_token')
         user = get_user_by_access_token(access_token)
         serializer_class = self.get_serializer_class()
-        return Response(serializer_class(user).data, status=status.HTTP_200_OK)
+        return Response(serializer_class(user).data)
 
     @auth_required(as_admin=False)
     @action(detail=False, methods=['post'])
@@ -178,7 +175,6 @@ class ProfileViewSet(GenericViewSet):
 
         return Response(
             {'message': 'Password reset successfully'},
-            status=status.HTTP_200_OK,
         )
 
     @auth_required(as_admin=False)
@@ -196,7 +192,7 @@ class ProfileViewSet(GenericViewSet):
             user=user,
             data=request.data,
         )
-        return Response(UserSerializer(updated_user).data, status=status.HTTP_200_OK)
+        return Response(UserSerializer(updated_user).data)
 
 
 class RefreshTokenView(TokenRefreshView):
@@ -233,7 +229,6 @@ class RefreshTokenView(TokenRefreshView):
                 {
                     'message': 'Successfully refreshed token',
                 },
-                status=status.HTTP_200_OK,
             )
 
             response.set_cookie(
@@ -281,7 +276,6 @@ class LogOutView(APIView):
             response.data = {
                 'message': 'Successfully logged out',
             }
-            response.status_code = status.HTTP_200_OK
 
             return response
         except Exception as e:
@@ -326,7 +320,6 @@ class ForgotPasswordView(generics.CreateAPIView):
 
         return Response(
             {'message': 'Password reset link sent successfully'},
-            status=status.HTTP_200_OK,
         )
 
 
@@ -356,7 +349,6 @@ class ForgotPasswordResetView(generics.UpdateAPIView):
 
             return Response(
                 {'message': 'Password reset successfully'},
-                status=status.HTTP_200_OK,
             )
         return Response(
             {'message': 'Invalid reset link'},
@@ -385,7 +377,6 @@ class AdminViewSet(GenericViewSet):
         send_verification_link_mail(request, user)
         return Response(
             {'message': 'A verification link has been sent to the user\'s email address'},
-            status=status.HTTP_200_OK,
         )
 
     @auth_required(as_admin=True)
@@ -403,7 +394,7 @@ class AdminViewSet(GenericViewSet):
             user=edit_user,
             data=request.data,
         )
-        return Response(UserSerializer(updated_user).data, status=status.HTTP_200_OK)
+        return Response(UserSerializer(updated_user).data)
 
     @auth_required(as_admin=True)
     @action(detail=False, methods=['post'])
@@ -415,7 +406,6 @@ class AdminViewSet(GenericViewSet):
         deactivate_user.save()
         return Response(
             {'message': 'The user was deactivated'},
-            status=status.HTTP_200_OK,
         )
 
     @auth_required(as_admin=True)
@@ -425,5 +415,4 @@ class AdminViewSet(GenericViewSet):
         # return all Users info
         return Response(
             serializer_class(User.objects.all(), many=True).data,
-            status=status.HTTP_200_OK,
         )

--- a/bublik/interfaces/api_v2/config.py
+++ b/bublik/interfaces/api_v2/config.py
@@ -132,14 +132,14 @@ class ConfigViewSet(ModelViewSet):
 
             if not update_data:
                 serializer = self.get_serializer(config)
-                return Response(serializer.data, status=status.HTTP_200_OK)
+                return Response(serializer.data)
 
             # if no new content is provided, just update the current config instance
             if 'content' not in update_data:
                 serializer = self.get_serializer(config, data=update_data, partial=True)
                 serializer.is_valid(raise_exception=True)
                 self.perform_update(serializer)
-                return Response(serializer.data, status=status.HTTP_200_OK)
+                return Response(serializer.data)
 
         # create a new config version if the provided content differs from all existing versions
         access_token = request.COOKIES.get('access_token')
@@ -163,7 +163,7 @@ class ConfigViewSet(ModelViewSet):
         serializer = self.get_serializer(updated_config, data=update_data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response(serializer.data)
 
     @auth_required(as_admin=True)
     def destroy(self, request, *args, **kwargs):
@@ -179,7 +179,7 @@ class ConfigViewSet(ModelViewSet):
         config_name = request.query_params.get('name')
         json_schema = ConfigServices.get_schema(config_type, config_name)
         if json_schema:
-            return Response(data=json_schema, status=status.HTTP_200_OK)
+            return Response(data=json_schema)
         msg = (
             'There is no JSON schema corresponding to the passed '
             f'configuration type-name: {config_type}-{config_name}'
@@ -209,7 +209,7 @@ class ConfigViewSet(ModelViewSet):
             'project': config_data['project'],
             'all_config_versions': all_config_versions,
         }
-        return Response(data, status=status.HTTP_200_OK)
+        return Response(data)
 
     @action(detail=False, methods=['get'])
     def available_types_names(self, request):
@@ -237,7 +237,7 @@ class ConfigViewSet(ModelViewSet):
                     'description': global_config.description,
                 },
             )
-        return Response({'config_types_names': config_type_names}, status=status.HTTP_200_OK)
+        return Response({'config_types_names': config_type_names})
 
     def list(self, request):
         '''
@@ -259,4 +259,4 @@ class ConfigViewSet(ModelViewSet):
                 'created',
             )
         )
-        return Response(configs_to_display, status=status.HTTP_200_OK)
+        return Response(configs_to_display)

--- a/bublik/interfaces/api_v2/dashboard.py
+++ b/bublik/interfaces/api_v2/dashboard.py
@@ -118,7 +118,7 @@ class DashboardViewSet(RetrieveModelMixin, GenericViewSet):
             'payload': self.payload.description,
         }
 
-        return Response(data=response, status=status.HTTP_200_OK)
+        return Response(data=response)
 
     @action(detail=False, methods=['get'])
     def default_mode(self, request):
@@ -132,7 +132,7 @@ class DashboardViewSet(RetrieveModelMixin, GenericViewSet):
                 data={'message': message},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
-        return Response(data={'mode': mode}, status=status.HTTP_200_OK)
+        return Response(data={'mode': mode})
 
     def prepare_settings(self):
         self.payload = DashboardPayload()

--- a/bublik/interfaces/api_v2/importruns.py
+++ b/bublik/interfaces/api_v2/importruns.py
@@ -107,7 +107,7 @@ class ImportrunsViewSet(ViewSet):
                 json_line = json.loads(line)
             json_log.append(json_line)
 
-        return Response(data=json_log, status=status.HTTP_200_OK)
+        return Response(data=json_log)
 
     @method_decorator(never_cache)
     @action(detail=False, methods=['post'], renderer_classes=[JSONRenderer])
@@ -123,7 +123,6 @@ class ImportrunsViewSet(ViewSet):
             cache.data = ctx
 
             return Response(
-                status=status.HTTP_200_OK,
                 data={'runid': ctx.run},
             )
         except json.decoder.JSONDecodeError:

--- a/bublik/interfaces/api_v2/log.py
+++ b/bublik/interfaces/api_v2/log.py
@@ -45,7 +45,7 @@ class LogViewSet(RetrieveModelMixin, GenericViewSet):
         run_source_link = get_sources(result)
 
         if not run_source_link:
-            return Response(data={'url': None}, status=status.HTTP_200_OK)
+            return Response(data={'url': None})
 
         page = request.query_params.get('page')
         if page and not page.isdigit():
@@ -78,12 +78,10 @@ class LogViewSet(RetrieveModelMixin, GenericViewSet):
 
             return Response(
                 data={'url': forwarding_url, 'attachments_url': attachments_url},
-                status=status.HTTP_200_OK,
             )
 
         return Response(
             data={'url': url, 'attachments_url': attachments_url},
-            status=status.HTTP_200_OK,
         )
 
     @action(detail=True, methods=['get'])
@@ -94,7 +92,7 @@ class LogViewSet(RetrieveModelMixin, GenericViewSet):
         '''
 
         result = self.get_object()
-        return Response(data={'url': get_result_log(result)}, status=status.HTTP_200_OK)
+        return Response(data={'url': get_result_log(result)})
 
     @action(detail=False, methods=['get'])
     def proxy(self, request):

--- a/bublik/interfaces/api_v2/performance.py
+++ b/bublik/interfaces/api_v2/performance.py
@@ -5,7 +5,6 @@ import logging
 from urllib.parse import urlencode
 
 from django.conf import settings
-from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -111,4 +110,4 @@ class PerformanceCheckView(APIView):
                 continue
             data.append(view_data)
 
-        return Response(data, status=status.HTTP_200_OK)
+        return Response(data)

--- a/bublik/interfaces/api_v2/report.py
+++ b/bublik/interfaces/api_v2/report.py
@@ -71,7 +71,7 @@ class ReportViewSet(RetrieveModelMixin, GenericViewSet):
                     ),
                 )
 
-        return Response({'run_report_configs': run_report_configs}, status=status.HTTP_200_OK)
+        return Response({'run_report_configs': run_report_configs})
 
     def retrieve(self, request, pk=None):
         r'''
@@ -192,4 +192,4 @@ class ReportViewSet(RetrieveModelMixin, GenericViewSet):
             'unprocessed_iters': unprocessed_iters,
         }
 
-        return Response(data=report, status=status.HTTP_200_OK)
+        return Response(data=report)

--- a/bublik/interfaces/api_v2/results.py
+++ b/bublik/interfaces/api_v2/results.py
@@ -126,17 +126,17 @@ class RunViewSet(ModelViewSet):
         for run in runs:
             kwargs.update({'run': run})
             RunCache.delete_data_for_obj(**kwargs)
-        return Response(data={'results': runs_ids}, status=status.HTTP_200_OK)
+        return Response(data={'results': runs_ids})
 
     @action(detail=True, methods=['get'])
     def nok_distribution(self, request, pk=None):
         run = self.get_object()
-        return Response(data=get_nok_results_distribution(run), status=status.HTTP_200_OK)
+        return Response(data=get_nok_results_distribution(run))
 
     @action(detail=True, methods=['get'])
     def details(self, request, pk=None):
         run = self.get_object()
-        return Response(data=generate_all_run_details(run), status=status.HTTP_200_OK)
+        return Response(data=generate_all_run_details(run))
 
     @action(detail=True, methods=['get'])
     def stats(self, request, pk=None):
@@ -332,13 +332,11 @@ class ResultViewSet(ModelViewSet):
         result = self.get_object()
         return Response(
             data={'result': generate_result_details(result)},
-            status=status.HTTP_200_OK,
         )
 
     def list(self, request):
         return Response(
             data={'results': generate_results_details(self.get_queryset())},
-            status=status.HTTP_200_OK,
         )
 
     @action(detail=True, methods=['get'])
@@ -348,7 +346,7 @@ class ResultViewSet(ModelViewSet):
             'artifacts': list(result_metas.filter(type='artifact').values()),
             'verdicts': list(result_metas.filter(type='verdict').values()),
         }
-        return Response(data, status=status.HTTP_200_OK)
+        return Response(data)
 
     @action(detail=True, methods=['get'])
     def measurements(self, request, pk=None):

--- a/bublik/interfaces/api_v2/tree.py
+++ b/bublik/interfaces/api_v2/tree.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
-from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.mixins import RetrieveModelMixin
 from rest_framework.response import Response
@@ -44,11 +43,10 @@ class TreeViewSet(RetrieveModelMixin, GenericViewSet):
 
         return Response(
             data={'tree': tree, 'main_package': main_package},
-            status=status.HTTP_200_OK,
         )
 
     @action(detail=True, methods=['get'])
     def path(self, request, pk=None):
         result = self.get_object()
         node_path = path_to_node(result)
-        return Response(data={'path': node_path}, status=status.HTTP_200_OK)
+        return Response(data={'path': node_path})

--- a/bublik/interfaces/api_v2/url_shortener.py
+++ b/bublik/interfaces/api_v2/url_shortener.py
@@ -63,4 +63,4 @@ class URLShortenerView(APIView):
         short_url_endpoint += f'short/{view}/{short_url_obj.hash}'
         short_url = build_absolute_uri(request, short_url_endpoint)
 
-        return Response(data={'short_url': short_url}, status=status.HTTP_200_OK)
+        return Response(data={'short_url': short_url})


### PR DESCRIPTION
Removed explicit HTTP 200 status codes from response objects since 200 is the default. This simplifies the code and reduces redundancy.