### PR TITLE
Management: fix reformat sequence settings of report config

### DIFF
--- a/bublik/core/config/reformatting/steps.py
+++ b/bublik/core/config/reformatting/steps.py
@@ -77,7 +77,7 @@ class UpdateSeqSettingsStructure(BaseReformatStep):
     def applied(self, config, **kwargs):
         content = config.content
         for _test_name, test_config_data in content['tests'].items():
-            if 'sequences' not in test_config_data:
+            if 'sequence_group_arg' in test_config_data:
                 return False
         return True
 


### PR DESCRIPTION
Since sequence split settings are optional, the absence of the `sequences` key should not be treated as an indicator that the configuration was not reformatted. Instead, the presence of the deprecated `sequence_group_arg` key should be used as a direct signal of the outdated structure.