### PR TITLE
Run data: fix runs tags retrieval

### DIFF
--- a/bublik/core/run/data.py
+++ b/bublik/core/run/data.py
@@ -66,6 +66,8 @@ def get_tags_by_runs(runs, not_categorize=False):
     Runs items can represent TestIterationResult objects or just IDs.
     """
 
+    runs = [run.id if hasattr(run, 'id') else run for run in runs]
+
     run_project_map = dict(
         TestIterationResult.objects.filter(id__in=runs).values_list('id', 'project_id'),
     )


### PR DESCRIPTION
Unify `runs` to a list of IDs to handle cases where it contains objects. This prevents errors and ensures correct tag retrieval for runs provided either as a list of objects or as a list of their IDs.