### PR TITLE
ci: remove redundant quote-style-check job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,21 +75,3 @@ jobs:
       - name: Run Flynt in check mode
         run: |
           echo "${{ needs.detect-changes.outputs.python_files }}" | xargs flynt -f
-
-  quote-style-check:
-    name: Check Quote Style Consistency
-    needs: detect-changes
-    runs-on: ubuntu-latest
-    if: ${{ needs.detect-changes.outputs.python_files != '' }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install Unify
-        run: pip install unify
-
-      - name: Run Unify in check mode
-        run: |
-          echo "${{ needs.detect-changes.outputs.python_files }}" | xargs unify -c --quote "'"


### PR DESCRIPTION
## Summary
- Removes the redundant `quote-style-check` job from the CI workflow

## Details
The `quote-style-check` job was duplicating functionality already covered by other linting/checking jobs in the CI pipeline. This change simplifies the workflow by removing the unnecessary job.
Also unify triggers false positives for these issues:
```
Strings nested within an f-string cannot use the same quote character as the f-string prior to Python 3.12 (basedpyright reportGeneralTypeIssues)
```

when it tries to convert f-strings like these `f'some text {obj['prop']}'`

```
Cannot reuse outer quote character in f-strings on Python 3.8 (syntax was added in Python 3.12) (Ruff)
```

## Files Changed
- `.github/workflows/ci.yaml`: Removed the standalone `quote-style-check` job (18 lines deleted)