### PR TITLE
history: convert history API dates to ISO8601 format

### DIFF
--- a/bublik/core/history/v2/utils.py
+++ b/bublik/core/history/v2/utils.py
@@ -141,7 +141,7 @@ def group_results(
     results,
     verdicts,
 ):
-    # Preare data for iteration group
+    # Prepare data for iteration group
     results_to_response = []
     for test_results in test_results_by_iteration:
         group = test_results[0]

--- a/bublik/core/history/v2/utils.py
+++ b/bublik/core/history/v2/utils.py
@@ -9,7 +9,7 @@ import urllib
 from deepdiff import DeepHash
 from django.conf import settings
 
-from bublik.core.datetime_formatting import display_to_milliseconds, get_duration
+from bublik.core.datetime_formatting import get_duration
 from bublik.core.run.stats import get_expected_results
 from bublik.core.run.utils import prepare_dates_period
 from bublik.core.utils import key_value_dict_transforming
@@ -36,7 +36,6 @@ def prepare_list_results(
     results,
     verdicts,
 ):
-
     results_to_response = []
     for test_result in test_results:
         run_id = test_result['run_id']
@@ -64,8 +63,8 @@ def prepare_list_results(
         metadata = metadata_by_runs.get(run_id, [])
 
         result = {
-            'start_date': display_to_milliseconds(result_start),
-            'finish_date': display_to_milliseconds(result_finish),
+            'start_date': result_start.isoformat(),
+            'finish_date': result_finish.isoformat(),
             'duration': get_duration(result_start, result_finish),
             'obtained_result': obtained_result_data,
             'expected_results': expected_results_data,
@@ -142,7 +141,6 @@ def group_results(
     results,
     verdicts,
 ):
-
     # Preare data for iteration group
     results_to_response = []
     for test_results in test_results_by_iteration:
@@ -168,7 +166,7 @@ def group_results(
                 {
                     'run_id': run_id,
                     'result_id': result_id,
-                    'start_date': test_result['start'].date(),
+                    'start_date': test_result['start'].isoformat(),
                     'result_type': results[result_id],
                     'verdict': verdicts.get(result_id, []),
                     'has_error': test_result['has_error'],

--- a/bublik/interfaces/api_v2/history.py
+++ b/bublik/interfaces/api_v2/history.py
@@ -14,7 +14,6 @@ from rest_framework.mixins import ListModelMixin
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
-from bublik.core.datetime_formatting import display_to_date_in_numbers
 from bublik.core.filter_backends import ProjectFilterBackend
 from bublik.core.history.v2.utils import (
     generate_hashkey,
@@ -340,8 +339,8 @@ class HistoryViewSet(ListModelMixin, GenericViewSet):
         if add_context is None:
             add_context = {}
         response = {
-            'from_date': display_to_date_in_numbers(self.from_date),
-            'to_date': display_to_date_in_numbers(self.to_date),
+            'from_date': self.from_date.isoformat(),
+            'to_date': self.to_date.isoformat(),
             'counts': counts,
             'pagination': self.paginator.get_pagination(),
             'results': response_list,


### PR DESCRIPTION
Update all date fields in the /api/v2/history/ endpoint to return ISO8601 format instead of custom formatted strings for better standardization. Because it's currently incorrectly returns dates in UTC while most of UI uses users timezone so we should deletage proper formatting to the UI.

Changes:
- start_date and finish_date now use isoformat() instead of display_to_milliseconds()
- from_date and to_date now use isoformat() instead of display_to_date_in_numbers()
- Removed unused imports for display_to_milliseconds and display_to_date_in_numbers

This is related to changes in this PR:
https://github.com/ts-factory/bublik-ui/pull/471