### PR TITLE
ci: use `black` version from `requirements.txt`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Black
-        run: pip install black
+        run: pip install $(grep '^black==' requirements.txt)
 
       - name: Run Black in check mode
         run: |


### PR DESCRIPTION
We should use pinned version from `requirements.txt` for black since new versions might introduce different formatting by default. This change is fixes some false positives and difference between using `black` formatter locally and CI.

For example in this PR we install latest black version and it formats file differently then locally installed one:
https://github.com/ts-factory/bublik/pull/266
Which triggers incorrect behaviour for failing job
https://github.com/ts-factory/bublik/actions/runs/21217354262/job/61042169900?pr=266