### PR TITLE
Events: add endpoint to fetch run by Celery task ID

### DIFF
--- a/bublik/core/exceptions.py
+++ b/bublik/core/exceptions.py
@@ -110,3 +110,8 @@ class BadGatewayError(BublikAPIError):
 class UnprocessableEntityError(BublikAPIError):
     status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
     default_detail = 'Unprocessable entity'
+
+
+class NotFoundError(BublikAPIError):
+    status_code = status.HTTP_404_NOT_FOUND
+    default_detail = 'Not found'


### PR DESCRIPTION
# Info
Add an endpoint to fetch the run created by a Celery task using its task ID.

# Overview of changes
## API
### GET /bublik/api/v2/session_import/\<celery_task_id\>/status/

**Description:**
Provides details of the run created by a Celery task identified by the given ID.

**Response data:**
1. If the importruns task completed successfully:
```
{
    "run_id": 1
}
```
**Status:** 200 OK

2. If the task is pending, failed, or cannot be found:
```
{
    "messages": [
        "Run corresponding to the passed Celery task ID doesn't exist"
    ]
}
```
**Status:** 404 Not Found

# Issues
Refs #272