### PR TITLE
requirements: update `python-dateutil` to fix deprecation warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ pyflakes==2.3.1
 pykerberos==1.2.4
 pylint==3.3.8
 pyparsing==3.1.2
-python-dateutil==2.8.2
+python-dateutil==2.9.0
 python-json-logger==2.0.7
 python-memcached==1.59
 pytype==2024.3.19


### PR DESCRIPTION
Currently `python-dateutil` 2.8.2 uses deprecated datetime.utcfromtimestamp().
Upgrade to 2.9.0 to fix this warning.

See deprecation notice:
https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp