### PR TITLE
Dashboard: improve navigation tooltip wording for consistency

### DIFF
--- a/bublik/interfaces/api_v2/dashboard.py
+++ b/bublik/interfaces/api_v2/dashboard.py
@@ -369,12 +369,12 @@ class DashboardPayload:
 
     handlers: typing.ClassVar['dict'] = {}
     handlers_available: typing.ClassVar['dict'] = {
-        'go_run': 'go to run details',
-        'go_run_failed': 'go to run details with failed results opened',
-        'go_tree': 'go to run tests as a tree with its logs and context',
-        'go_bug': 'go to bug in the repository',
-        'go_source': 'go to source from which the run was imported',
-        'go_report': 'go to the most recent report',
+        'go_run': 'Go to Run',
+        'go_run_failed': 'Go to Run (Preview NOK)',
+        'go_tree': 'Go to Log',
+        'go_bug': 'Go to Bug',
+        'go_source': 'Go to Run Source',
+        'go_report': 'Go to Report (Most Recent)',
     }
 
     def __call__(self, settings):


### PR DESCRIPTION
Update navigation tooltips to use page-based naming for better UX consistency.

Before:
<img width="726" height="230" alt="Снимок экрана 2026-02-17 в 15 05 48" src="https://github.com/user-attachments/assets/1c1c2472-3e0c-4ef5-920c-ba2ef012185f" />

After:
<img width="725" height="235" alt="Снимок экрана 2026-02-17 в 15 04 23" src="https://github.com/user-attachments/assets/2744f882-3b29-44bb-8c4b-3ec5dc2b39c7" />
