### PR TITLE
Run data: make VCS tags visible in revisions list in run details

### DIFF
--- a/bublik/core/queries.py
+++ b/bublik/core/queries.py
@@ -53,3 +53,6 @@ class MetaResultsQuery:
         return self.query_to_values(
             q=Q(meta__type='tag') & Q(meta__category__priority__range=(1, 3)),
         )
+
+    def revision_related_query(self):
+        return self.query_to_values(Q(meta__type__in=['revision', 'vcs-tag']))

--- a/bublik/core/run/stats.py
+++ b/bublik/core/run/stats.py
@@ -655,7 +655,7 @@ def generate_all_run_details(run):
     q = MetaResultsQuery(run_meta_results)
 
     branches = q.metas_query('branch')
-    revisions = build_revision_references(q.metas_query('revision'), project.id)
+    revisions = build_revision_references(q.revision_related_query(), project.id)
     labels = q.labels_query(category_names, project.id)
     configurations = list(
         key_value_list_transforming(


### PR DESCRIPTION
Include VCS tags in the revisions list so they are now shown in the run details:

<img width="1454" height="416" alt="Снимок экрана 2026-02-17 в 14 57 36" src="https://github.com/user-attachments/assets/0189f033-ae70-4775-8dd8-1aca7ffef802" />
