### PR TITLE
Config: remove ConfigFilterSet  and add HTTP methods list

### DIFF
--- a/bublik/interfaces/api_v2/config.py
+++ b/bublik/interfaces/api_v2/config.py
@@ -3,9 +3,7 @@
 
 import typing
 
-from django.contrib.postgres.fields import JSONField
 from django.db import transaction
-from django_filters import rest_framework as filters
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
 from rest_framework.decorators import action
@@ -20,20 +18,6 @@ from bublik.core.filter_backends import ProjectFilterBackend
 from bublik.core.shortcuts import serialize
 from bublik.data.models import Config, ConfigTypes, GlobalConfigs, Project, UserRoles
 from bublik.data.serializers import ConfigSerializer
-
-
-class ConfigFilterSet(filters.FilterSet):
-    class Meta:
-        model = Config
-        fields: typing.ClassVar = ['type', 'name', 'is_active', 'version']
-        filter_overrides: typing.ClassVar = {
-            JSONField: {
-                'filter_class': filters.CharFilter,
-                'extra': lambda f: {
-                    'lookup_expr': 'icontains',
-                },
-            },
-        }
 
 
 class ConfigViewSet(ModelViewSet):

--- a/bublik/interfaces/api_v2/config.py
+++ b/bublik/interfaces/api_v2/config.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
 
+from __future__ import annotations
+
 import typing
 
 from django.db import transaction
@@ -25,6 +27,14 @@ class ConfigViewSet(ModelViewSet):
     serializer_class = ConfigSerializer
     filterset_class = ConfigFilter
     filter_backends: typing.ClassVar[list] = [ProjectFilterBackend, DjangoFilterBackend]
+    http_method_names: typing.ClassVar[list[str]] = [
+        'get',
+        'post',
+        'patch',
+        'delete',
+        'head',
+        'options',
+    ]
 
     def get_queryset(self):
         configs = self.filter_queryset(super().get_queryset())


### PR DESCRIPTION
This PR cleans up the ConfigViewSet and restricts allowed HTTP methods:

## Changes

- **Remove unused ConfigFilterSet**  
  The filter set was not being used anywhere in the codebase. This cleanup reduces unnecessary code and improves maintainability.

- **Restrict allowed HTTP methods in ConfigViewSet**  
  Explicitly define `http_method_names` to allow only `GET`, `POST`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS`. This follows security best practices by limiting the available methods and preventing unintended `PUT` requests.

## Why

- Removes dead code that could cause confusion
- Improves API security by explicitly allowing only needed methods
- Follows project standards for HTTP method restrictions