### PR TITLE
importruns: support series aggregation type in MI logs

### DIFF
--- a/bublik/core/importruns/milog.py
+++ b/bublik/core/importruns/milog.py
@@ -382,8 +382,20 @@ class HandlerArtifacts:
                 for _, entries_group in groupby(entries, key=entries_by_measurements):
                     serial += 1
                     entries_group = list(entries_group)
-                    values = [entry['value'] for entry in entries_group]
+                    values = []
+                    for entry in entries_group:
+                        if 'values' in entry and 'value' in entry:
+                            logger.warning(
+                                'entry contains both "value" and "values" — "value" will be '
+                                'ignored. Check your MI logs.',
+                            )
+                        if 'values' in entry:
+                            values += entry['values']
+                        else:
+                            values += [entry['value']]
                     entry = entries_group[0]
+                    if 'values' in entry:
+                        del entry['values']
                     entry['value'] = values
                     try:
                         entrylvl = EntryLevel(entry, serial, resultlvl)


### PR DESCRIPTION
Simply append the values list as if each individual value came from a separate entry record.

Requires the following TE patch series: https://github.com/oktetlabs/test-environment/pull/102