### PR TITLE
Requirements: fix Python 3.12+ incompatibility by dropping XStatic-Treeview

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -102,7 +102,6 @@ urllib3==2.6.3
 uvicorn[standard]
 vine==5.1.0
 xlwt==1.3.0
-XStatic-Patternfly-Bootstrap-Treeview==2.1.3.2
 yamale==5.2.1
 yapf==0.31.0
 zipp==3.20.2


### PR DESCRIPTION
Remove XStatic-Patternfly-Bootstrap-Treeview dependency as it is unused, not required by any package, and incompatible with Python 3.12+.