### PR TITLE
Requirements: fix missing MCP server startup dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,6 +66,7 @@ pip-tools
 pipdeptree==2.2.1
 pre-commit==3.3.2
 psycopg2-binary==2.9.10
+py-key-value-aio[disk]==0.4.4
 pycodestyle==2.7.0
 pycparser==2.19
 pydot==2.0.0


### PR DESCRIPTION
Added missing dependencies required for MCP server startup, including py-key-value-aio and its extras (diskcache, pathvalidate), which were not installed previously, likely because they are optional and were previously present only transitively or in a non-clean environment.