### PR TITLE
api: Add project badges to see the pipe status externally

### DIFF
--- a/bublik/core/project/__init__.py
+++ b/bublik/core/project/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2025-2026 OKTET Labs Ltd. All rights reserved.
 
-from bublik.core.project.services import ProjectService
+from bublik.core.project.services import ProjectBadgeService, ProjectService
 
 
-__all__ = ['ProjectService']
+__all__ = ['ProjectBadgeService', 'ProjectService']

--- a/bublik/core/project/services.py
+++ b/bublik/core/project/services.py
@@ -3,11 +3,16 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 from django.core.exceptions import ObjectDoesNotExist
+from django.template.loader import render_to_string
 from rest_framework.exceptions import ValidationError
 
 from bublik.core.exceptions import NotFoundError
+from bublik.core.run.stats import get_run_conclusion, get_run_stats
 from bublik.data import models
+from bublik.data.models import TestIterationResult
 from bublik.data.serializers import ProjectSerializer
 
 
@@ -126,3 +131,260 @@ class ProjectService:
             msg = 'Unable to delete: there are runs linked to this project'
             raise ValidationError(msg)
         project.delete()
+
+
+class ProjectBadgeService:
+    # Thresholds for badge color logic
+    _UNEXPECTED_WARNING_THRESHOLD = 0.2
+    _RATE_PASSING_THRESHOLD = 90
+    _RATE_WARNING_THRESHOLD = 70
+
+    # Hex values taken from shields.io's named palette (CC0 1.0):
+    # https://github.com/badges/shields/blob/master/badge-maker/lib/color.js
+    COLORS: ClassVar[dict] = {
+        'passing': '#4c1',
+        'failing': '#e05d44',
+        'warning': '#fe7d37',
+        'pending': '#dfb317',
+        'unknown': '#9f9f9f',
+        'info': '#007ec6',
+    }
+
+    # Per-character width table for Verdana 11px.
+    # Verdana was chosen by shields.io because it is the standard font for
+    # flat-style SVG badges (see badge-renderers.js: WIDTH_FONT = '11px Verdana')
+    # and was designed specifically for screen readability at small sizes.
+    # 11px is the size that produces the classic badge appearance used across
+    # the open-source ecosystem.
+    #
+    # Derived from the anafanafo package (MIT, Copyright 2018 Metabolize LLC),
+    # used by shields.io badge-maker (CC0 1.0) to measure text widths
+    # server-side without a browser or canvas:
+    # https://github.com/metabolize/anafanafo/blob/main/packages/anafanafo/data/verdana-11px-normal.json
+    #
+    # Used to approximate text width server-side so that each badge section
+    # can be sized correctly.  The values are in units of 1/10 px at
+    # font-size="110"; the SVG uses transform="scale(.1)" to render them
+    # at the actual 11 px size.
+    _WIDTHS: ClassVar[dict] = {
+        ' ': 3.87,
+        '!': 4.33,
+        '"': 5.05,
+        '#': 9.0,
+        '$': 6.99,
+        '%': 11.84,
+        '&': 7.99,
+        "'": 2.95,
+        '(': 5.0,
+        ')': 5.0,
+        '*': 6.99,
+        '+': 9.0,
+        ',': 4.0,
+        '-': 5.0,
+        '.': 4.0,
+        '/': 5.0,
+        '0': 6.99,
+        '1': 6.99,
+        '2': 6.99,
+        '3': 6.99,
+        '4': 6.99,
+        '5': 6.99,
+        '6': 6.99,
+        '7': 6.99,
+        '8': 6.99,
+        '9': 6.99,
+        ':': 5.0,
+        ';': 5.0,
+        '<': 9.0,
+        '=': 9.0,
+        '>': 9.0,
+        '?': 6.0,
+        '@': 11.0,
+        'A': 7.52,
+        'B': 7.54,
+        'C': 7.68,
+        'D': 8.48,
+        'E': 6.96,
+        'F': 6.32,
+        'G': 8.53,
+        'H': 8.27,
+        'I': 4.63,
+        'J': 5.0,
+        'K': 7.62,
+        'L': 6.12,
+        'M': 9.27,
+        'N': 8.23,
+        'O': 8.66,
+        'P': 6.63,
+        'Q': 8.66,
+        'R': 7.65,
+        'S': 7.52,
+        'T': 6.78,
+        'U': 8.05,
+        'V': 7.52,
+        'W': 10.88,
+        'X': 7.54,
+        'Y': 6.77,
+        'Z': 7.54,
+        '[': 5.0,
+        '\\': 5.0,
+        ']': 5.0,
+        '^': 9.0,
+        '_': 6.99,
+        '`': 6.99,
+        'a': 6.61,
+        'b': 6.85,
+        'c': 5.73,
+        'd': 6.85,
+        'e': 6.55,
+        'f': 3.87,
+        'g': 6.85,
+        'h': 6.96,
+        'i': 3.02,
+        'j': 3.79,
+        'k': 6.51,
+        'l': 3.02,
+        'm': 10.7,
+        'n': 6.96,
+        'o': 6.68,
+        'p': 6.85,
+        'q': 6.85,
+        'r': 4.69,
+        's': 5.73,
+        't': 4.33,
+        'u': 6.96,
+        'v': 6.51,
+        'w': 9.0,
+        'x': 6.51,
+        'y': 6.51,
+        'z': 5.78,
+        '{': 6.98,
+        '|': 5.0,
+        '}': 6.98,
+        '~': 9.0,
+    }
+
+    @staticmethod
+    def _text_width(text):
+        '''Return approximate pixel width of text rendered in Verdana 11px.'''
+        return sum(ProjectBadgeService._WIDTHS.get(c, 6.0) for c in text)
+
+    @staticmethod
+    def render(label, value, color, label_color='#555') -> str:
+        '''Generate an SVG badge matching shields.io flat style.'''
+        label_tw = ProjectBadgeService._text_width(label)
+        value_tw = ProjectBadgeService._text_width(value)
+
+        # Badge section widths: textWidth + 10px padding each side
+        label_width = int(label_tw + 10)
+        value_width = int(value_tw + 10)
+        total_width = label_width + value_width
+
+        # Text x-centers and textLength values (x10 because of scale(.1))
+        label_x = int(label_width / 2 * 10)
+        value_x = int((label_width + value_width / 2) * 10)
+        label_tl = int(label_tw * 10)
+        value_tl = int(value_tw * 10)
+
+        return render_to_string(
+            'bublik/badge.svg.template',
+            {
+                'label': label,
+                'value': value,
+                'color': color,
+                'label_color': label_color,
+                'total_width': total_width,
+                'label_width': label_width,
+                'value_width': value_width,
+                'label_x': label_x,
+                'value_x': value_x,
+                'label_tl': label_tl,
+                'value_tl': value_tl,
+            },
+        )
+
+    @staticmethod
+    def get_latest_run(project):
+        '''Return the most recent top-level run for the given project, or None.'''
+        return (
+            TestIterationResult.objects.filter(project=project, test_run__isnull=True)
+            .order_by('-start')
+            .first()
+        )
+
+    @staticmethod
+    def run_conclusion(run) -> tuple:
+        """Return (status_text, color) for a run using Bublik's built-in logic."""
+        try:
+            conclusion, _ = get_run_conclusion(run)
+        except Exception:
+            return 'unknown', ProjectBadgeService.COLORS['unknown']
+
+        return {
+            'run-ok': ('passing', ProjectBadgeService.COLORS['passing']),
+            'run-running': ('running', ProjectBadgeService.COLORS['info']),
+            'run-warning': ('warning', ProjectBadgeService.COLORS['warning']),
+            'run-error': ('failing', ProjectBadgeService.COLORS['failing']),
+            'run-stopped': ('stopped', ProjectBadgeService.COLORS['unknown']),
+            'run-busy': ('busy', ProjectBadgeService.COLORS['pending']),
+            'run-compromised': ('compromised', ProjectBadgeService.COLORS['warning']),
+            'run-interrupted': ('interrupted', ProjectBadgeService.COLORS['warning']),
+        }.get(conclusion, ('unknown', ProjectBadgeService.COLORS['unknown']))
+
+    @staticmethod
+    def _rate_badge(passed, total) -> tuple:
+        """Return (value, color) for the 'rate' metric."""
+        if total == 0:
+            return 'N/A', ProjectBadgeService.COLORS['unknown']
+        rate = passed / total * 100
+        if rate >= ProjectBadgeService._RATE_PASSING_THRESHOLD:
+            color = ProjectBadgeService.COLORS['passing']
+        elif rate >= ProjectBadgeService._RATE_WARNING_THRESHOLD:
+            color = ProjectBadgeService.COLORS['warning']
+        else:
+            color = ProjectBadgeService.COLORS['failing']
+        return f'{rate:.1f}%', color
+
+    @staticmethod
+    def badge_content(run, metric: str) -> tuple:
+        """
+        Given a run (may be None) and metric string, return (value, color).
+
+        If run is None, returns ('no runs', gray color).
+        """
+        if run is None:
+            return 'no runs', ProjectBadgeService.COLORS['unknown']
+
+        try:
+            stats = get_run_stats(run.id)
+        except Exception:
+            return 'error', ProjectBadgeService.COLORS['failing']
+
+        total = stats.get('total', 0)
+        unexpected = stats.get('unexpected', 0)
+        passed = total - unexpected
+
+        if metric == 'passed':
+            return str(passed), ProjectBadgeService.COLORS['passing']
+
+        if metric == 'unexpected':
+            if total == 0:
+                color = ProjectBadgeService.COLORS['unknown']
+            elif unexpected == 0:
+                color = ProjectBadgeService.COLORS['passing']
+            elif unexpected / total < ProjectBadgeService._UNEXPECTED_WARNING_THRESHOLD:
+                color = ProjectBadgeService.COLORS['warning']
+            else:
+                color = ProjectBadgeService.COLORS['failing']
+            return str(unexpected), color
+
+        if metric == 'total':
+            return str(total), ProjectBadgeService.COLORS['info']
+
+        if metric == 'rate':
+            return ProjectBadgeService._rate_badge(passed, total)
+
+        # default: show run conclusion + unexpected count
+        status_text, status_color = ProjectBadgeService.run_conclusion(run)
+        value = f'{status_text} ({unexpected} nok)' if unexpected > 0 else status_text
+        return value, status_color

--- a/bublik/interfaces/api_v2/project.py
+++ b/bublik/interfaces/api_v2/project.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2025 OKTET Labs Ltd. All rights reserved.
 
+from django.http import HttpResponse
 from rest_framework import status
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
 from bublik.core.auth import auth_required
-from bublik.core.project import ProjectService
+from bublik.core.project import ProjectBadgeService, ProjectService
 from bublik.data.serializers import ProjectSerializer
 
 
@@ -60,3 +62,21 @@ class ProjectViewSet(ModelViewSet):
         queryset = self.filter_queryset(self.get_queryset())
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
+
+    @action(detail=True, methods=['get'], url_path='badge')
+    def badge(self, request, pk=None):
+        '''
+        SVG badge for the latest run of a project.
+
+        Query parameters:
+            label   (optional) -- left-side text; defaults to project name
+            metric  (optional) -- passed | unexpected | total | rate
+                                   default shows run conclusion with nok count
+        '''
+        project = self.get_object()
+        label = request.query_params.get('label') or project.name
+        metric = request.query_params.get('metric', '').lower()
+        run = ProjectBadgeService.get_latest_run(project)
+        value, color = ProjectBadgeService.badge_content(run, metric)
+        svg = ProjectBadgeService.render(label, value, color)
+        return HttpResponse(svg, content_type='image/svg+xml')

--- a/bublik/representation/templates/bublik/badge.svg.template
+++ b/bublik/representation/templates/bublik/badge.svg.template
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="{{ total_width }}"
+    height="20"
+    role="img"
+    aria-label="{{ label }}: {{ value }}"
+>
+  <title>{{ label }}: {{ value }}</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+    <stop offset="1" stop-opacity=".1" />
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="{{ total_width }}" height="20" rx="3" fill="#fff" />
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="{{ label_width }}" height="20" fill="{{ label_color }}" />
+    <rect
+            x="{{ label_width }}"
+            width="{{ value_width }}"
+            height="20"
+            fill="{{ color }}"
+        />
+    <rect width="{{ total_width }}" height="20" fill="url(#s)" />
+  </g>
+  <g
+        fill="#fff"
+        text-anchor="middle"
+        font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
+        text-rendering="geometricPrecision"
+        font-size="110"
+    >
+    <text
+            aria-hidden="true"
+            x="{{ label_x }}"
+            y="150"
+            fill="#010101"
+            fill-opacity=".3"
+            transform="scale(.1)"
+            textLength="{{ label_tl }}"
+        >{{ label }}</text>
+    <text
+            x="{{ label_x }}"
+            y="140"
+            transform="scale(.1)"
+            fill="#fff"
+            textLength="{{ label_tl }}"
+        >{{ label }}</text>
+    <text
+            aria-hidden="true"
+            x="{{ value_x }}"
+            y="150"
+            fill="#010101"
+            fill-opacity=".3"
+            transform="scale(.1)"
+            textLength="{{ value_tl }}"
+        >{{ value }}</text>
+    <text
+            x="{{ value_x }}"
+            y="140"
+            transform="scale(.1)"
+            fill="#fff"
+            textLength="{{ value_tl }}"
+        >{{ value }}</text>
+  </g>
+</svg>

--- a/bublik/tests/test_badge.py
+++ b/bublik/tests/test_badge.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Interpretica, Unipessoal Lda. All rights reserved.
+
+import re
+
+from django.test import TestCase
+from rest_framework import status
+
+from bublik.core.project import ProjectBadgeService
+from bublik.data.models import Project
+
+
+class BadgeSVGTest(TestCase):
+    def test_svg_structure(self):
+        svg = ProjectBadgeService.render('label', 'value', '#4c1')
+        assert '<svg' in svg
+        assert '</svg>' in svg
+        assert 'label' in svg
+        assert 'value' in svg
+        assert '#4c1' in svg
+
+    def test_width_grows_with_text(self):
+        short = ProjectBadgeService.render('a', 'b', '#4c1')
+        long = ProjectBadgeService.render('long label', 'long value', '#4c1')
+
+        def w(s):
+            return int(re.search(r'width="(\d+)"', s).group(1))
+
+        assert w(long) > w(short)
+
+    def test_text_width_nonempty(self):
+        assert ProjectBadgeService._text_width('hello') > 0
+
+    def test_unknown_char_fallback(self):
+        svg = ProjectBadgeService.render('тест', '★', '#555')
+        assert '<svg' in svg
+
+
+class BadgeEndpointTest(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name='test-project')
+
+    def test_badge_returns_svg(self):
+        url = f'/api/v2/projects/{self.project.id}/badge/'
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response['Content-Type'] == 'image/svg+xml'
+
+    def test_badge_unknown_project(self):
+        response = self.client.get('/api/v2/projects/99999/badge/')
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_badge_no_runs(self):
+        url = f'/api/v2/projects/{self.project.id}/badge/'
+        response = self.client.get(url)
+        assert b'no runs' in response.content


### PR DESCRIPTION
Badge logic is encapsulated in ProjectBadgeService
(bublik/core/project/services.py) and exposed via a dedicated action
on ProjectViewSet.

Endpoint:
  GET /api/v2/projects/{id}/badge/[?metric=METRIC][&label=TEXT]

Supported metrics:
  (default)  run conclusion with unexpected count, e.g. "warning (2 nok)"
  passed     number of passed tests
  unexpected number of unexpected results
  total      total number of tests
  rate       pass rate as a percentage