### PR TITLE
Run: fix same-name test results mixing and clarify run stats field naming

### DIFF
--- a/bublik/core/result/services.py
+++ b/bublik/core/result/services.py
@@ -106,6 +106,7 @@ class ResultService:
     def list_results(
         parent_id: int | None = None,
         test_name: str | None = None,
+        start_tir_id: str | None = None,
         results: str | None = None,
         result_properties: str | None = None,
         requirements: str | None = None,
@@ -116,6 +117,7 @@ class ResultService:
         Args:
             parent_id: Filter by parent package ID
             test_name: Filter by test name
+            start_tir_id: Filter by the starting ID of a consecutive result sequence
             results: Comma-separated result statuses
             result_properties: Comma-separated result properties
             requirements: Comma-separated requirement names
@@ -160,6 +162,23 @@ class ResultService:
 
         queryset = queryset.filter(queries)
 
+        # filtering by ID to retain consecutive results
+        if start_tir_id:
+            start_tir_id = int(start_tir_id)
+            all_tir_ids = list(queryset.order_by('id').values_list('id', flat=True).distinct())
+
+            if start_tir_id not in all_tir_ids:
+                return models.TestIterationResult.objects.none()
+
+            start = all_tir_ids.index(start_tir_id)
+            target_ids = []
+            for i, tir_id in enumerate(all_tir_ids[start:]):
+                if tir_id != start_tir_id + i:
+                    break
+                target_ids.append(tir_id)
+
+            queryset = queryset.filter(id__in=target_ids)
+
         # result_properties filtering
         if result_properties:
             queryset = queryset.filter_by_result_classification(
@@ -197,6 +216,7 @@ class ResultService:
     def list_results_paginated(
         parent_id: int | None = None,
         test_name: str | None = None,
+        start_tir_id: str | None = None,
         results: str | None = None,
         result_properties: str | None = None,
         requirements: str | None = None,
@@ -209,6 +229,7 @@ class ResultService:
         Args:
             parent_id: Filter by parent package ID
             test_name: Filter by test name
+            start_tir_id: Filter by the starting ID of a consecutive result sequence
             results: Comma-separated result statuses
             result_properties: Comma-separated result properties
             requirements: Comma-separated requirement names
@@ -221,6 +242,7 @@ class ResultService:
         queryset = ResultService.list_results(
             parent_id=parent_id,
             test_name=test_name,
+            start_tir_id=start_tir_id,
             results=results,
             result_properties=result_properties,
             requirements=requirements,

--- a/bublik/core/run/stats.py
+++ b/bublik/core/run/stats.py
@@ -83,12 +83,12 @@ def generate_result(
     parent_id = test_iter_res.parent_package.id if test_iter_res.parent_package else None
 
     test_iter_res_info = {
-        'result_id': test.id,
-        'iteration_id': test_iter_res.id,
+        'result_id': test_iter_res.id,
         'exec_seqno': test_iter_res.exec_seqno,
         'parent_id': parent_id,
         'type': test.get_result_type_display(),
-        'name': test_name,
+        'test_id': test.id,
+        'test_name': test_name,
         'period': period_to_str(period),
         'path': path,
         'objective': objectives.get(test_iter_res.id, ''),

--- a/bublik/interfaces/api_v2/results.py
+++ b/bublik/interfaces/api_v2/results.py
@@ -148,6 +148,7 @@ class ResultViewSet(ModelViewSet):
     def get_queryset(self):
         parent_id = self.request.query_params.get('parent_id')
         test_name = self.request.query_params.get('test_name')
+        start_tir_id = self.request.query_params.get('start_tir_id')
         results = self.request.query_params.get('results')
         result_properties = self.request.query_params.get('result_properties')
         requirements = self.request.query_params.get('requirements')
@@ -155,6 +156,7 @@ class ResultViewSet(ModelViewSet):
         return ResultService.list_results(
             parent_id=parent_id,
             test_name=test_name,
+            start_tir_id=start_tir_id,
             results=results,
             result_properties=result_properties,
             requirements=requirements,

--- a/bublik/mcp/tools.py
+++ b/bublik/mcp/tools.py
@@ -147,6 +147,7 @@ def register_tools(mcp: FastMCP):  # noqa: C901
     async def list_results(
         parent_id: int,
         test_name: str,
+        start_tir_id: str,
         results: str | None = None,
         result_properties: str | None = None,
         requirements: str | None = None,
@@ -159,6 +160,7 @@ def register_tools(mcp: FastMCP):  # noqa: C901
         Args:
             parent_id: Filter by parent package ID
             test_name: Filter by test name
+            start_tir_id: Filter by the starting ID of a consecutive result sequence
             results: Semicolon-separated result statuses
                 (e.g., 'PASSED;FAILED;SKIPPED;KILLED;CORED;FAKED;INCOMPLETE')
             result_properties: Semicolon-separated result properties
@@ -173,6 +175,7 @@ def register_tools(mcp: FastMCP):  # noqa: C901
         return await sync_to_async(ResultService.list_results_paginated)(
             parent_id=parent_id,
             test_name=test_name,
+            start_tir_id=start_tir_id,
             results=results,
             result_properties=result_properties,
             requirements=requirements,


### PR DESCRIPTION
# Info

This PR improves the clarity and correctness of run statistics data handling.

It introduces a more precise way to retrieve test results when multiple tests share the same name under a common parent. Previously, filtering by name could return mixed results from different test groups. To address this, a new `start_tir_id` parameter was added, allowing identification of a specific consecutive group of results starting from a given iteration result ID.

In addition, the structure of run stats response data was refined. Fields representing test iteration result ID, test ID, and test name were renamed to better reflect their actual meaning and to align with naming conventions used across other APIs.

# Overview of changes
## API
### GET /bublik/api/v2/runs/<run ID\>/stats/
**Response data:**
Before:
```
{
    "results": {
        "result_id": 66,
        "iteration_id": 96,
        "exec_seqno": 1,
        "parent_id": null,
        "type": "pkg",
        "name": "dpdk-ethdev-ts",
        "period": "1776634253s425-1776649614s895",
        "path": [
            "dpdk-ethdev-ts"
        ],
        "objective": "DPDM EthDev Test Suite",
        "children": [
            {
                "result_id": 67,
                "iteration_id": 97,
                "exec_seqno": 2,
                "parent_id": 96,
                "type": "test",
                "name": "prologue",
                "period": "1776634253s426-1776634273s89",
                "path": [
                    "dpdk-ethdev-ts",
                    "prologue"
                ],
                "objective": "",
                "children": [],
                "stats": {
                    "passed": 1,
                    "failed": 0,
                    "passed_unexpected": 0,
                    "failed_unexpected": 0,
                    "skipped": 0,
                    "skipped_unexpected": 0,
                    "abnormal": 0
                },
                "comments": []
            },
```
After:
```
{
    "results": {
        "result_id": 96,
        "exec_seqno": 1,
        "parent_id": null,
        "type": "pkg",
        "test_id": 66,
        "test_name": "dpdk-ethdev-ts",
        "period": "1776634253s425-1776649614s895",
        "path": [
            "dpdk-ethdev-ts"
        ],
        "objective": "DPDM EthDev Test Suite",
        "children": [
            {
                "result_id": 97,
                "exec_seqno": 2,
                "parent_id": 96,
                "type": "test",
                "test_id": 67,
                "test_name": "prologue",
                "period": "1776634253s426-1776634273s89",
                "path": [
                    "dpdk-ethdev-ts",
                    "prologue"
                ],
                "objective": "",
                "children": [],
                "stats": {
                    "passed": 1,
                    "failed": 0,
                    "passed_unexpected": 0,
                    "failed_unexpected": 0,
                    "skipped": 0,
                    "skipped_unexpected": 0,
                    "abnormal": 0
                },
                "comments": []
            },
            ...
```
⚠️ **Breaking change:** Three fields have been renamed for clarity:
- iteration_id → result_id,
- result_id → test_id,
- name → test_name.

### GET /bublik/api/v2/results/
New query parameter: 
`start_tir_id` (int) – ID of the first test iteration result belonging to the test. Used to avoid mixed results when multiple tests share the same name under a common parent.

# UI Requirements

See "Overview of changes > API"

# Deployment

**Note:** Due to changes in the statistics format, the statistics cache must be cleared for all runs. To do so, execute the following command:

```
python manage.py run_cache delete -f 2017.01.01 -d stats -d stats_reqs
```