### PR TITLE
History: add test search options endpoint

### DIFF
--- a/bublik/core/cache.py
+++ b/bublik/core/cache.py
@@ -153,6 +153,10 @@ class ProjectCache:
     def tags(self):
         return _TagsCache(self)
 
+    @property
+    def tests(self):
+        return _TestsCache(self)
+
 
 class _ProjectSectionCache:
     '''
@@ -261,3 +265,57 @@ class _TagsCache(_ProjectSectionCache):
         self.set('important', prepare_tags(important_tags_data))
         self.set('relevant', prepare_tags(relevant_tags_data))
         self.set('all', prepare_tags(tags_data))
+
+
+class _TestsCache(_ProjectSectionCache):
+    SECTION = 'tests'
+    KEY_DATA_CHOICES: ClassVar[set] = {
+        'test_names_and_paths',
+    }
+
+    def load(self):
+        all_nodes = models.Test.objects.only('id', 'name', 'parent_id', 'result_type')
+        all_nodes_by_id = {n.id: n for n in all_nodes}
+
+        test_entity = models.ResultType.conv('test')
+
+        if self._project._project_id is not None:
+            project_node_ids = set(
+                models.TestIterationResult.objects.filter(project_id=self._project._project_id)
+                .values_list('iteration__test_id', flat=True)
+                .distinct(),
+            )
+            tests = sorted(
+                (
+                    node
+                    for node in all_nodes_by_id.values()
+                    if node.result_type == test_entity and node.id in project_node_ids
+                ),
+                key=lambda n: n.name,
+            )
+        else:
+            tests = sorted(
+                (node for node in all_nodes_by_id.values() if node.result_type == test_entity),
+                key=lambda n: n.name,
+            )
+
+        seen = set()
+        test_search_options = []
+
+        for test in tests:
+            path = []
+            node = test
+            while node:
+                path.append(node.name)
+                node = all_nodes_by_id.get(node.parent_id)
+            path_str = '/'.join(reversed(path))
+
+            if test.name not in seen:
+                seen.add(test.name)
+                test_search_options.append(test.name)
+
+            if path_str not in seen:
+                seen.add(path_str)
+                test_search_options.append(path_str)
+
+        self.set('test_names_and_paths', test_search_options)

--- a/bublik/core/history/services.py
+++ b/bublik/core/history/services.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from django.conf import settings
 from django.db.models import Exists, F, OuterRef, Q
 
+from bublik.core.cache import ProjectCache
 from bublik.core.datetime_formatting import display_to_date_in_numbers
 from bublik.core.exceptions import NotFoundError
 from bublik.core.history.v2.utils import (
@@ -28,8 +29,6 @@ from bublik.data.models import (
     MeasurementResult,
     Meta,
     MetaResult,
-    ResultType,
-    Test,
     TestArgument,
     TestIteration,
     TestIterationResult,
@@ -626,48 +625,9 @@ class HistoryService:
 
     @staticmethod
     def get_test_search_options(project_id: str | None):
-        all_nodes = Test.objects.only('id', 'name', 'parent_id', 'result_type')
-        all_nodes_by_id = {n.id: n for n in all_nodes}
-
-        test_entity = ResultType.conv('test')
-
-        if project_id is not None:
-            project_node_ids = set(
-                TestIterationResult.objects.filter(project_id=project_id)
-                .values_list('iteration__test_id', flat=True)
-                .distinct(),
-            )
-            tests = sorted(
-                (
-                    node
-                    for node in all_nodes_by_id.values()
-                    if node.result_type == test_entity and node.id in project_node_ids
-                ),
-                key=lambda n: n.name,
-            )
-        else:
-            tests = sorted(
-                (node for node in all_nodes_by_id.values() if node.result_type == test_entity),
-                key=lambda n: n.name,
-            )
-
-        seen = set()
-        test_search_options = []
-
-        for test in tests:
-            path = []
-            node = test
-            while node:
-                path.append(node.name)
-                node = all_nodes_by_id.get(node.parent_id)
-            path_str = '/'.join(reversed(path))
-
-            if test.name not in seen:
-                seen.add(test.name)
-                test_search_options.append(test.name)
-
-            if path_str not in seen:
-                seen.add(path_str)
-                test_search_options.append(path_str)
-
-        return test_search_options
+        tests_cache = ProjectCache(project_id).tests
+        test_names_and_paths = tests_cache.get('test_names_and_paths')
+        if test_names_and_paths is not None:
+            return test_names_and_paths
+        tests_cache.load()
+        return tests_cache.get('test_names_and_paths')

--- a/bublik/core/history/services.py
+++ b/bublik/core/history/services.py
@@ -28,6 +28,8 @@ from bublik.data.models import (
     MeasurementResult,
     Meta,
     MetaResult,
+    ResultType,
+    Test,
     TestArgument,
     TestIteration,
     TestIterationResult,
@@ -621,3 +623,51 @@ class HistoryService:
             'results': response_list,
             'results_ids': list(results_ids),
         }
+
+    @staticmethod
+    def get_test_search_options(project_id: str | None):
+        all_nodes = Test.objects.only('id', 'name', 'parent_id', 'result_type')
+        all_nodes_by_id = {n.id: n for n in all_nodes}
+
+        test_entity = ResultType.conv('test')
+
+        if project_id is not None:
+            project_node_ids = set(
+                TestIterationResult.objects.filter(project_id=project_id)
+                .values_list('iteration__test_id', flat=True)
+                .distinct(),
+            )
+            tests = sorted(
+                (
+                    node
+                    for node in all_nodes_by_id.values()
+                    if node.result_type == test_entity and node.id in project_node_ids
+                ),
+                key=lambda n: n.name,
+            )
+        else:
+            tests = sorted(
+                (node for node in all_nodes_by_id.values() if node.result_type == test_entity),
+                key=lambda n: n.name,
+            )
+
+        seen = set()
+        test_search_options = []
+
+        for test in tests:
+            path = []
+            node = test
+            while node:
+                path.append(node.name)
+                node = all_nodes_by_id.get(node.parent_id)
+            path_str = '/'.join(reversed(path))
+
+            if test.name not in seen:
+                seen.add(test.name)
+                test_search_options.append(test.name)
+
+            if path_str not in seen:
+                seen.add(path_str)
+                test_search_options.append(path_str)
+
+        return test_search_options

--- a/bublik/interfaces/api_v2/history.py
+++ b/bublik/interfaces/api_v2/history.py
@@ -4,6 +4,7 @@
 from django.core.cache import cache
 from rest_framework.decorators import action
 from rest_framework.mixins import ListModelMixin
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
@@ -76,3 +77,9 @@ class HistoryViewSet(ListModelMixin, GenericViewSet):
             response_data.update(add_context)
 
         return Response(response_data)
+
+    @action(detail=False, methods=['get'], renderer_classes=[JSONRenderer])
+    def test_search_options(self, request, pk=None):
+        project_id = request.query_params.get('project')
+        test_search_options = HistoryService.get_test_search_options(project_id)
+        return Response(test_search_options)

--- a/bublik/interfaces/management/commands/project_cache.py
+++ b/bublik/interfaces/management/commands/project_cache.py
@@ -16,6 +16,7 @@ class Command(BaseCommand):
     PROJECT_SECTION_CHOICES: ClassVar[set] = {
         'configs',
         'tags',
+        'tests',
     }
 
     def add_arguments(self, parser):
@@ -51,6 +52,8 @@ class Command(BaseCommand):
                     ProjectCache(pid).configs.clear_all()
                 elif data_key == 'tags':
                     ProjectCache(pid).tags.clear_all()
+                elif data_key == 'tests':
+                    ProjectCache(pid).tests.clear_all()
 
     def load_cache(self, project_ids, data_keys):
         for data_key in data_keys:
@@ -63,6 +66,9 @@ class Command(BaseCommand):
             elif data_key == 'tags':
                 for pid in project_ids:
                     ProjectCache(pid).tags.load()
+            elif data_key == 'tests':
+                for pid in project_ids:
+                    ProjectCache(pid).tests.load()
 
     def handle(self, *args, **options):
         try:

--- a/bublik/interfaces/signals.py
+++ b/bublik/interfaces/signals.py
@@ -15,6 +15,8 @@ from bublik.data.models import (
     Meta,
     MetaResult,
     MetaTest,
+    Project,
+    Test,
     TestIterationResult,
 )
 
@@ -36,6 +38,17 @@ def update_config_cache(sender, instance, **kwargs):
 def delete_config_cache(sender, instance, **kwargs):
     if instance.type == ConfigTypes.GLOBAL and instance.is_active:
         ProjectCache(instance.project_id).configs.delete(instance.name)
+
+
+@receiver(post_save, sender=Test)
+def delete_tests_cache(sender, instance, created, **kwargs):
+    if not created:
+        return
+    ProjectCache(None).tests.clear_all()
+    # Test is created before TestIterationResult, so it's impossible to determine
+    # which projects are affected. Invalidate cache for all projects.
+    for project_id in Project.objects.values_list('id', flat=True):
+        ProjectCache(project_id).tests.clear_all()
 
 
 @receiver(post_delete, sender=Config)


### PR DESCRIPTION
# Info
This PR adds a `GET /history/test_search_options/` endpoint that returns test names and their full paths for use in search/autocomplete UI, backed by a project-level cache.

# Overview of changes
## API
### GET /bublik/api/v2/history/test_search_options/
Returns a deduplicated list of test names and their full paths (e.g. *suite/group/test_name*) for use in search/autocomplete UI.

**Query parameters:**
- `project` (integer, None; optional) – project ID to filter results. If omitted, returns tests across all projects.

**Response data:**
```
[
    "test_name1",
    "suite/group/test_name1",
    "test_name2",
    "suite/test_name2"
]
```