### PR TITLE
runs: optimize runs statistics charts with backend aggregation

### DIFF
--- a/bublik/core/run/services.py
+++ b/bublik/core/run/services.py
@@ -3,11 +3,16 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+from enum import Enum
+
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
+from django.db.models import Count, Q
 from rest_framework.exceptions import ValidationError
 
+from bublik.core.config.services import ConfigServices
 from bublik.core.exceptions import NotFoundError
 from bublik.core.pagination_helpers import PaginatedResult
 from bublik.core.run.compromised import (
@@ -28,6 +33,19 @@ from bublik.core.run.stats import (
 from bublik.core.shortcuts import serialize
 from bublik.data import models
 from bublik.data.serializers import RunCommentSerializer
+
+
+class RunsChartGroupBy(str, Enum):
+    '''
+    Supported periods for grouping runs chart data.
+    '''
+
+    DAY = 'day'
+    WEEK = 'week'
+
+    @classmethod
+    def values(cls) -> tuple[str, ...]:
+        return tuple(item.value for item in cls)
 
 
 class RunService:
@@ -263,6 +281,199 @@ class RunService:
         )
         runs_details = generate_runs_details(runs)
         return PaginatedResult.paginate_queryset(runs_details, page, page_size)
+
+    @staticmethod
+    def aggregate_runs_by_period(
+        queryset,
+        group_by: RunsChartGroupBy = RunsChartGroupBy.DAY,
+    ) -> dict:
+        '''
+        Build aggregated chart data for runs.
+
+        Args:
+            queryset: QuerySet with runs to include in charts.
+            group_by: Time period for grouping chart buckets.
+
+        Returns:
+            Dictionary with chart buckets. Each bucket contains bucket date,
+            test counters, passrate and run IDs grouped by conclusion.
+        '''
+
+        runs = list(queryset.values('id', 'start', 'project_id'))
+
+        if not runs:
+            return {'buckets': []}
+
+        run_ids = [run['id'] for run in runs]
+        project_id_by_run_id = {run['id']: run['project_id'] for run in runs}
+        project_ids = {run['project_id'] for run in runs}
+
+        status_meta_name_by_project_id = {
+            project_id: ConfigServices.getattr_from_global(
+                models.GlobalConfigs.PER_CONF.name,
+                'RUN_STATUS_META',
+                project_id,
+            )
+            for project_id in project_ids
+        }
+
+        meta_names = {
+            'compromised',
+            'driver_unload',
+        }
+        meta_names.update(
+            status_meta_name
+            for status_meta_name in status_meta_name_by_project_id.values()
+            if status_meta_name
+        )
+
+        run_metas = models.MetaResult.objects.filter(
+            result_id__in=run_ids,
+            meta__name__in=meta_names,
+        ).values(
+            'result_id',
+            'meta__name',
+            'meta__value',
+        )
+
+        run_meta_by_run_id = {}
+
+        for run_meta in run_metas:
+            run_id = run_meta['result_id']
+            meta_name = run_meta['meta__name']
+            meta_value = run_meta['meta__value']
+
+            if run_id not in run_meta_by_run_id:
+                run_meta_by_run_id[run_id] = {}
+
+            run_meta_by_run_id[run_id][meta_name] = meta_value
+
+        buckets_by_date = {}
+        bucket_date_by_run_id = {}
+
+        for run in runs:
+            start = run['start']
+            bucket_date = start.replace(hour=0, minute=0, second=0, microsecond=0)
+
+            if group_by == RunsChartGroupBy.WEEK:
+                bucket_date -= timedelta(days=bucket_date.weekday())
+
+            if bucket_date not in buckets_by_date:
+                buckets_by_date[bucket_date] = []
+
+            buckets_by_date[bucket_date].append(run['id'])
+            bucket_date_by_run_id[run['id']] = bucket_date
+
+        test_stats = (
+            models.TestIterationResult.objects.filter(
+                test_run_id__in=run_ids,
+                iteration__test__result_type=models.ResultType.conv(models.ResultType.TEST),
+            )
+            .values('test_run_id')
+            .annotate(
+                total=Count('id', distinct=True),
+                nok=Count('id', filter=Q(meta_results__meta__type='err'), distinct=True),
+            )
+        )
+
+        tests_by_date = {}
+        tests_by_run_id = {}
+
+        for stat in test_stats:
+            run_id = stat['test_run_id']
+            total = stat['total']
+            nok = stat['nok']
+            ok = total - nok
+            bucket_date = bucket_date_by_run_id[run_id]
+
+            tests_by_run_id[run_id] = {
+                'total': total,
+                'nok': nok,
+                'ok': ok,
+            }
+
+            if bucket_date not in tests_by_date:
+                tests_by_date[bucket_date] = {
+                    'total': 0,
+                    'ok': 0,
+                    'nok': 0,
+                }
+
+            tests_by_date[bucket_date]['total'] += total
+            tests_by_date[bucket_date]['ok'] += ok
+            tests_by_date[bucket_date]['nok'] += nok
+
+        buckets = []
+
+        def make_empty_run_ids_by_status():
+            return {status: [] for status in models.RunConclusion.all()}
+
+        run_ids_by_status_by_date = {}
+
+        for run_id in run_ids:
+            bucket_date = bucket_date_by_run_id[run_id]
+
+            if bucket_date not in run_ids_by_status_by_date:
+                run_ids_by_status_by_date[bucket_date] = make_empty_run_ids_by_status()
+
+            project_id = project_id_by_run_id[run_id]
+            run_meta_by_name = run_meta_by_run_id.get(run_id, {})
+            run_tests = tests_by_run_id.get(run_id, {'total': 0, 'nok': 0})
+
+            status_meta_name = status_meta_name_by_project_id[project_id]
+            run_status = run_meta_by_name.get(status_meta_name)
+            run_compromised = 'compromised' in run_meta_by_name
+            driver_unload = run_meta_by_name.get('driver_unload')
+
+            run_status_by_nok, unexpected_percent = models.RunStatusByUnexpected.identify(
+                {
+                    'total': run_tests['total'],
+                    'unexpected': run_tests['nok'],
+                },
+                project_id,
+            )
+
+            conclusion, _reason = models.RunConclusion.identify(
+                run_status,
+                run_status_by_nok,
+                unexpected_percent,
+                run_compromised,
+                driver_unload,
+                project_id,
+            )
+
+            run_ids_by_status_by_date[bucket_date][conclusion].append(run_id)
+
+        for bucket_date in sorted(buckets_by_date):
+            tests = tests_by_date.get(
+                bucket_date,
+                {
+                    'ok': 0,
+                    'nok': 0,
+                    'total': 0,
+                },
+            )
+            passrate = round(tests['ok'] * 100 / tests['total'], 2) if tests['total'] else 0
+
+            run_ids_by_status = run_ids_by_status_by_date.get(
+                bucket_date,
+                make_empty_run_ids_by_status(),
+            )
+
+            buckets.append(
+                {
+                    'date': bucket_date,
+                    'tests': {
+                        'ok': tests['ok'],
+                        'nok': tests['nok'],
+                        'total': tests['total'],
+                        'passrate': passrate,
+                    },
+                    'run_ids_by_status': run_ids_by_status,
+                },
+            )
+
+        return {'buckets': buckets}
 
     @staticmethod
     def get_run_requirements(run_id: int) -> list[str]:

--- a/bublik/interfaces/api_v2/results.py
+++ b/bublik/interfaces/api_v2/results.py
@@ -11,7 +11,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from bublik.core.cache import RunCache
 from bublik.core.result import ResultService
-from bublik.core.run.services import RunService
+from bublik.core.run.services import RunsChartGroupBy, RunService
 from bublik.core.run.stats import (
     generate_results_details,
     generate_runs_details,
@@ -56,6 +56,20 @@ class RunViewSet(ModelViewSet):
                 'pagination': self.paginator.get_pagination(),
                 'results': generate_runs_details(results),
             },
+        )
+
+    @action(detail=False, methods=['get'])
+    def charts(self, request):
+        group_by_value = request.query_params.get('group_by', RunsChartGroupBy.DAY.value)
+
+        try:
+            group_by = RunsChartGroupBy(group_by_value)
+        except ValueError as e:
+            err_msg = f'group_by must be one of: {", ".join(RunsChartGroupBy.values())}'
+            raise ValidationError(err_msg) from e
+
+        return Response(
+            RunService.aggregate_runs_by_period(self.get_queryset(), group_by=group_by),
         )
 
     @action(detail=False, methods=['post'])


### PR DESCRIPTION
## Info

This PR moves runs charts aggregation from the UI to the backend.

Previously, the runs statistics view relied on `GET /bublik/api/v2/runs/`, fetched full run objects, and aggregated chart data on the client side. That approach caused unnecessary data transfer, additional database load, and slow chart rendering for larger datasets.

This change introduces a dedicated charts endpoint that performs server-side aggregation and returns precomputed bucketed statistics for the UI.

## Overview of changes

### API

New endpoint:

`GET /bublik/api/v2/runs/charts/`

Supported query parameters:
- `group_by`: `day` | `week` (default: `day`)
- `start_date`
- `finish_date`
- `tag_expr`
- `branch_expr`
- `project`
- `run_metas`

Response shape:

```json
{
  "buckets": [
    {
      "date": "2026-01-19T00:00:00Z",
      "tests": {
        "ok": 245,
        "nok": 12,
        "total": 257,
        "passrate": 95.33
      },
      "run_ids_by_status": {
        "run-ok": [101, 102],
        "run-error": [103],
        "run-warning": [],
        "run-running": [],
        "run-compromised": [],
        "run-busy": [],
        "run-stopped": [],
        "run-interrupted": []
      }
    }
  ]
}
```
## Aggregation logic

The endpoint now:
- groups runs by day or ISO week
- aggregates test statistics on the server
- computes final run conclusions per run
- groups run IDs by final status inside each bucket

Run status grouping is calculated using existing backend logic and project-specific configuration:
- `RUN_STATUS_META`
- `RUN_STATUS_BY_NOK_BORDERS`
- `compromised`
- `driver_unload`

## UI Requirements

The UI should use `/bublik/api/v2/runs/charts/` for chart data instead of aggregating over `/bublik/api/v2/runs/` on the client side.

## Notes

The backend currently accepts `run_metas` as the metadata filter parameter.

## Issue

Related to #273 
