### PR TITLE
Config: consolidate dashboard column configuration

### DIFF
--- a/bublik/core/config/reformatting/piplines.py
+++ b/bublik/core/config/reformatting/piplines.py
@@ -7,6 +7,7 @@ from bublik.core.config.reformatting.steps import (
     AllowMultipleSeriesArgs,
     BaseReformatStep,
     ImproveMetaStructure,
+    MergeDashboardSettings,
     RemoveUnsupportedAttributes,
     RenameSequencesToOverlayBy,
     SimplifyMetaStructure,
@@ -55,6 +56,7 @@ class PerConfConfigReformatPipeline(ReformatPipeline):
         super().__init__()
         self.add_step(UpdateDashboardHeaderStructure())
         self.add_step(UpdateCSRFTrustedOrigins())
+        self.add_step(MergeDashboardSettings())
 
 
 class ReferencesConfigReformatPipeline(ReformatPipeline):

--- a/bublik/core/config/reformatting/steps.py
+++ b/bublik/core/config/reformatting/steps.py
@@ -4,6 +4,7 @@
 import logging
 
 from bublik.core.config.services import ConfigServices
+from bublik.data.models import ConfigTypes, GlobalConfigs
 
 
 logger = logging.getLogger('colored')
@@ -391,4 +392,59 @@ class AllowMultipleSeriesArgs(BaseReformatStep):
                     test_config_data['overlay_by'],
                 ]
         config.content = content
+        return config
+
+
+class MergeDashboardSettings(BaseReformatStep):
+    def applied(self, config, **kwargs):
+        content = config.content
+        return not any(
+            db_setting in content for db_setting in ['DASHBOARD_HEADER', 'DASHBOARD_PAYLOAD']
+        )
+
+    def reformat(self, config, **kwargs):
+        db_header = config.content.get(
+            'DASHBOARD_HEADER',
+        ) or ConfigServices.getattr_from_global(
+            GlobalConfigs.PER_CONF.name,
+            'DASHBOARD_HEADER',
+            config.project,
+        )
+        db_payload = config.content.get(
+            'DASHBOARD_PAYLOAD',
+        ) or ConfigServices.getattr_from_global(
+            GlobalConfigs.PER_CONF.name,
+            'DASHBOARD_PAYLOAD',
+            config.project,
+        )
+
+        schema = ConfigServices.get_schema(
+            ConfigTypes.GLOBAL,
+            GlobalConfigs.PER_CONF.name,
+        )
+        builtin_column_keys = [
+            item['const']
+            for item in schema['properties']['DASHBOARD_COLUMNS']['items']['properties']['key'][
+                'anyOf'
+            ]
+            if 'const' in item
+        ]
+
+        db_columns = []
+        for db_header_col in db_header:
+            if 'key' not in db_header_col or 'label' not in db_header_col:
+                continue
+            if db_header_col['key'] == 'progress':
+                db_header_col['formatting'] = 'percent'
+            payload = db_payload.get(db_header_col['key'])
+            if payload:
+                if payload == 'go_tree':
+                    payload = 'go_log'
+                db_header_col['payload'] = payload
+            if db_header_col['key'] not in builtin_column_keys:
+                db_header_col['key'] = db_header_col.pop('label')
+            db_columns.append(db_header_col)
+
+        config.content['DASHBOARD_COLUMNS'] = db_columns
+
         return config

--- a/bublik/core/dashboard/services.py
+++ b/bublik/core/dashboard/services.py
@@ -28,8 +28,7 @@ class DashboardService:
     def get_dashboard_data(
         date: str,
         project_id: int | None = None,
-        header: dict | None = None,
-        formatting_settings: dict | None = None,
+        columns: dict | None = None,
         sort_config: list | None = None,
     ) -> dict:
         '''
@@ -38,8 +37,8 @@ class DashboardService:
         Args:
             date: Date string in 'yyyy-mm-dd' format
             project_id: Optional project ID to filter by
-            header: Optional header dict mapping keys to labels (fetched from config if None)
-            formatting_settings: Optional dict mapping keys to formatting methods
+            columns: Optional columns dict mapping keys to labels,
+                     payloads and formatters (fetched from config if None)
             sort_config: Optional list of column keys to sort by
 
         Returns:
@@ -49,14 +48,14 @@ class DashboardService:
             UnprocessableEntityError: if date format is invalid or config missing
         '''
 
-        # Get dashboard header configuration (required) if not provided
-        if header is None:
-            header_config = ConfigServices.getattr_from_global(
+        # Get dashboard columns configuration (required) if not provided
+        if columns is None:
+            columns_config = ConfigServices.getattr_from_global(
                 GlobalConfigs.PER_CONF.name,
-                'DASHBOARD_HEADER',
+                'DASHBOARD_COLUMNS',
                 project_id,
             )
-            header = {item['key']: item['label'] for item in header_config}
+            columns = {item.pop('key'): item for item in columns_config}
 
         # Get date meta setting (optional)
         date_meta = ConfigServices.getattr_from_global(
@@ -88,7 +87,7 @@ class DashboardService:
         rows_data = []
         for run in runs:
             conclusion, conclusion_reason = get_run_conclusion(run)
-            row_cells = DashboardService.prepare_row_data(run, header)
+            row_cells = DashboardService.prepare_row_data(run, columns)
             rows_data.append(
                 {
                     'row_cells': row_cells,
@@ -105,9 +104,8 @@ class DashboardService:
                 },
             )
 
-        # Apply formatting if provided
-        if formatting_settings:
-            DashboardService._apply_formatting(rows_data, formatting_settings)
+        # Apply formatting
+        DashboardService.apply_dashboard_formatting(rows_data, columns)
 
         # Apply sorting if provided
         if sort_config:
@@ -116,61 +114,27 @@ class DashboardService:
         return {
             'date': date,
             'rows': rows_data,
-            'header': [{'key': k, 'name': n} for k, n in header.items()],
+            'header': [{'key': k, 'name': lp.get('label') or k} for k, lp in columns.items()],
             'payload': {},  # Simplified for MCP (no URL handlers needed)
         }
 
     @staticmethod
-    def apply_dashboard_formatting(rows_data: list, formatting_settings: dict):
+    def apply_dashboard_formatting(rows_data: list, columns: dict):
         '''
         Apply formatting rules to dashboard row cells.
 
-        This is a public method that validates formatting methods before applying them.
         Available formatters: 'percent'.
 
         Args:
             rows_data: List of row dictionaries with 'row_cells' key
-            formatting_settings: Dict mapping keys to formatting method names
-                                 (e.g., {'progress': 'percent'})
-
-        Raises:
-            UnprocessableEntityError: if unknown formatting method specified
-        '''
-        available_formatters = {'percent'}
-
-        # Validate formatting methods
-        unknown_methods = set(formatting_settings.values()) - available_formatters
-        if unknown_methods:
-            msg = (
-                f"Unknown formatting method(s): {', '.join(unknown_methods)}. "
-                f"Available: {', '.join(available_formatters)}"
-            )
-            raise UnprocessableEntityError(msg)
-
-        for row in rows_data:
-            for key, method_name in formatting_settings.items():
-                if key in row['row_cells']:
-                    cell_data = row['row_cells'][key]
-                    if method_name == 'percent':
-                        DashboardService._format_percent(cell_data)
-
-    @staticmethod
-    def _apply_formatting(rows_data: list, formatting_settings: dict):
-        '''
-        Apply formatting rules to row cells.
-
-        Internal method that does not validate. Use apply_dashboard_formatting()
-        for public access with validation.
-
-        Args:
-            rows_data: List of row dictionaries with 'row_cells' key
-            formatting_settings: Dict mapping keys to formatting method names
+            columns: Columns dict mapping keys to labels, payloads
+                     and formatters
         '''
         for row in rows_data:
-            for key, method_name in formatting_settings.items():
+            for key, col_settings in columns.items():
                 if key in row['row_cells']:
                     cell_data = row['row_cells'][key]
-                    if method_name == 'percent':
+                    if col_settings.get('formatting') == 'percent':
                         DashboardService._format_percent(cell_data)
 
     @staticmethod
@@ -226,13 +190,13 @@ class DashboardService:
                 format_value(item)
 
     @staticmethod
-    def prepare_row_data(run, header):
+    def prepare_row_data(run, columns):
         '''
         Prepare row cells data for a run.
 
         Args:
             run: TestIterationResult instance
-            header: Dictionary mapping column keys to category names
+            columns: Dictionary mapping column keys to column label and payload
 
         Returns:
             Dictionary with row cells data
@@ -249,7 +213,7 @@ class DashboardService:
             metabased_data = list(
                 run.meta_results.select_related('meta')
                 .filter(
-                    meta__category__name__in=header.values(),
+                    meta__category__name__in=columns,
                     meta__category__project_id=run.project.id,
                 )
                 .annotate(category=F('meta__category__name'), value=F('meta__value'))
@@ -261,9 +225,9 @@ class DashboardService:
             row_data = {}
             extended_keys = ['total', 'total_expected', 'progress', 'unexpected']
             stats = get_run_stats(run.id)
-            for key, category in header.items():
+            for key, _col_settings in columns.items():
                 if key not in extended_keys:
-                    row_data[key] = metabased_dict.get(category, [])
+                    row_data[key] = metabased_dict.get(key, [])
                 else:
                     row_data[key] = [{'value': stats.get(key, '')}]
 
@@ -340,17 +304,17 @@ class DashboardService:
 
         # Get header (required setting)
         try:
-            header_config = ConfigServices.getattr_from_global(
+            columns_config = ConfigServices.getattr_from_global(
                 GlobalConfigs.PER_CONF.name,
-                'DASHBOARD_HEADER',
+                'DASHBOARD_COLUMNS',
                 project_id,
             )
-            header = {item['key']: item['label'] for item in header_config}
+            columns = {item.pop('key'): item for item in columns_config}
         except Exception as e:
-            errors.append(f'DASHBOARD_HEADER: {e}')
+            errors.append(f'DASHBOARD_COLUMNS: {e}')
 
         if not errors:
-            header_keys = set(header.keys())
+            columns_keys = set(columns.keys())
 
             # Validate DASHBOARD_RUNS_SORT keys match header
             try:
@@ -361,75 +325,14 @@ class DashboardService:
                     default=['start'],
                 )
                 sort_keys = set(sort_config) - {'start'}  # 'start' is always valid
-                diff = get_difference(sort_keys, header_keys)
+                diff = get_difference(sort_keys, columns_keys)
                 if diff:
                     errors.append(
-                        f"DASHBOARD_RUNS_SORT doesn't match DASHBOARD_HEADER, mismatch: {diff}",
+                        f"DASHBOARD_RUNS_SORT doesn't match DASHBOARD_COLUMNS, "
+                        f"mismatch: {diff}",
                     )
             except Exception as e:
                 errors.append(f'DASHBOARD_RUNS_SORT: {e}')
-
-            # Validate DASHBOARD_PAYLOAD keys match header
-            try:
-                payload_settings = ConfigServices.getattr_from_global(
-                    GlobalConfigs.PER_CONF.name,
-                    'DASHBOARD_PAYLOAD',
-                    project_id,
-                    default={},
-                )
-                available_payload_handlers = {
-                    'go_run',
-                    'go_run_failed',
-                    'go_tree',
-                    'go_bug',
-                    'go_source',
-                    'go_report',
-                }
-                payload_keys = set(payload_settings.keys())
-                diff = get_difference(payload_keys, header_keys)
-                if diff:
-                    errors.append(
-                        f"DASHBOARD_PAYLOAD doesn't match DASHBOARD_HEADER, mismatch: {diff}",
-                    )
-                # Validate payload handler names
-                diff_handlers = get_difference(
-                    payload_settings.values(),
-                    available_payload_handlers,
-                )
-                if diff_handlers:
-                    errors.append(
-                        f"Unknown value(s) in DASHBOARD_PAYLOAD: {', '.join(diff_handlers)}",
-                    )
-            except Exception as e:
-                errors.append(f'DASHBOARD_PAYLOAD: {e}')
-
-            # Validate DASHBOARD_FORMATTING
-            try:
-                formatting_settings = ConfigServices.getattr_from_global(
-                    GlobalConfigs.PER_CONF.name,
-                    'DASHBOARD_FORMATTING',
-                    project_id,
-                    default={'progress': 'percent'},
-                )
-                available_formatters = {'percent'}
-                formatting_keys = set(formatting_settings.keys())
-                diff = get_difference(formatting_keys, header_keys, ignore=['progress'])
-                if diff:
-                    errors.append(
-                        "DASHBOARD_FORMATTING doesn't match DASHBOARD_HEADER, "
-                        f"mismatch: {diff}",
-                    )
-                # Validate formatter method names
-                diff_methods = get_difference(
-                    formatting_settings.values(),
-                    available_formatters,
-                )
-                if diff_methods:
-                    errors.append(
-                        f"Unknown value(s) in DASHBOARD_FORMATTING: {', '.join(diff_methods)}",
-                    )
-            except Exception as e:
-                errors.append(f'DASHBOARD_FORMATTING: {e}')
 
         if errors:
             if raise_on_error:

--- a/bublik/data/schemas/per_conf.json
+++ b/bublik/data/schemas/per_conf.json
@@ -21,66 +21,103 @@
             },
             "uniqueItems": true
         },
-        "DASHBOARD_HEADER": {
+        "DASHBOARD_COLUMNS": {
             "description": "Sets columns on dashboard",
             "type": "array",
             "items": {
                 "type": "object",
                 "properties": {
                     "key": {
-                        "type": "string"
+                        "description": "Meta category name or built-in key",
+                        "anyOf": [
+                            {
+                                "const": "total",
+                                "description": "Total number of tests"
+                            },
+                            {
+                                "const": "total_expected",
+                                "description": "Total number of planned tests"
+                            },
+                            {
+                                "const": "progress",
+                                "description": "Ratio of executed tests to planned tests"
+                            },
+                            {
+                                "const": "unexpected",
+                                "description": "Number of tests with unexpected results"
+                            },
+                            {
+                                "type": "string",
+                                "description": "Meta category name"
+                            }
+                        ]
                     },
                     "label": {
+                        "description": "Displayed column name",
                         "type": "string"
+                    },
+                    "payload": {
+                        "description": "Sets link available by click on column values",
+                        "oneOf": [
+                            {
+                                "const": "go_run",
+                                "description": "Go to Run"
+                            },
+                            {
+                                "const": "go_run_failed",
+                                "description": "Go to Run (Preview NOK)"
+                            },
+                            {
+                                "const": "go_log",
+                                "description": "Go to Log"
+                            },
+                            {
+                                "const": "go_bug",
+                                "description": "Go to Bug"
+                            },
+                            {
+                                "const": "go_source",
+                                "description": "Go to Run Source"
+                            },
+                            {
+                                "const": "go_report",
+                                "description": "Go to Report (Most Recent)"
+                            }
+                        ]
+                    },
+                    "formatting": {
+                        "type": "string",
+                        "enum": ["percent"]
                     }
                 },
+                "required": ["key"],
                 "additionalProperties": false
             },
+            "uniqueItems": true,
             "default": [
                 {
-                    "key": "status",
-                    "label": "Status"
+                    "key": "Status"
                 },
                 {
                     "key": "total",
-                    "label": "Total"
+                    "label": "Total",
+                    "payload": "go_log"
                 },
                 {
                     "key": "unexpected",
-                    "label": "NOK"
+                    "label": "NOK",
+                    "payload": "go_run_failed"
                 },
                 {
                     "key": "progress",
-                    "label": "Progress"
+                    "label": "Progress",
+                    "formatting": "percent"
                 },
                 {
-                    "key": "notes",
-                    "label": "Notes"
+                    "key": "Notes",
+                    "payload": "go_bug"
                 }
             ]
-        },
-        "DASHBOARD_PAYLOAD": {
-            "description": "Sets link available by click on column values",
-            "type": "object",
-            "additionalProperties": {
-                "type": "string",
-                "items": {
-                    "type": "string"
-                },
-                "enum": [
-                    "go_run",
-                    "go_run_failed",
-                    "go_tree",
-                    "go_bug",
-                    "go_source",
-                    "go_report"
-                ]
-            },
-            "default": {
-                "total": "go_tree",
-                "unexpected": "go_run_failed",
-                "notes": "go_bug"
-            }
         },
         "DASHBOARD_DATE": {
             "description": "Represents the name of the meta pointing to which date the run is related to",

--- a/bublik/interfaces/api_v2/dashboard.py
+++ b/bublik/interfaces/api_v2/dashboard.py
@@ -17,7 +17,7 @@ from bublik.core.dashboard import DashboardService
 from bublik.core.report.services import ReportService
 from bublik.core.run.external_links import get_sources
 from bublik.core.utils import get_difference
-from bublik.data.models import GlobalConfigs, TestIterationResult
+from bublik.data.models import ConfigTypes, GlobalConfigs, TestIterationResult
 
 
 __all__ = [
@@ -231,12 +231,13 @@ class DashboardPayload:
     '''
 
     handlers_available: typing.ClassVar['dict'] = {
-        'go_run': 'Go to Run',
-        'go_run_failed': 'Go to Run (Preview NOK)',
-        'go_log': 'Go to Log',
-        'go_bug': 'Go to Bug',
-        'go_source': 'Go to Run Source',
-        'go_report': 'Go to Report (Most Recent)',
+        item['const']: item['description']
+        for item in ConfigServices.get_schema(
+            ConfigTypes.GLOBAL,
+            GlobalConfigs.PER_CONF.name,
+        )[
+            'properties'
+        ]['DASHBOARD_COLUMNS']['items']['properties']['payload']['oneOf']
     }
 
     def __init__(self):

--- a/bublik/interfaces/api_v2/dashboard.py
+++ b/bublik/interfaces/api_v2/dashboard.py
@@ -54,8 +54,7 @@ class DashboardViewSet(RetrieveModelMixin, GenericViewSet):
         data = DashboardService.get_dashboard_data(
             date,
             project_id,
-            header=self.header,
-            formatting_settings=self.formatting_settings,
+            columns=self.columns,
             sort_config=self.sort,
         )
 
@@ -92,12 +91,12 @@ class DashboardViewSet(RetrieveModelMixin, GenericViewSet):
             return False
 
         # Load settings (now known to be valid)
-        header = ConfigServices.getattr_from_global(
+        columns_config = ConfigServices.getattr_from_global(
             GlobalConfigs.PER_CONF.name,
-            'DASHBOARD_HEADER',
+            'DASHBOARD_COLUMNS',
             project_id,
         )
-        self.header = {item['key']: item['label'] for item in header}
+        self.columns = {item.pop('key'): item for item in columns_config}
         self.date_meta = ConfigServices.getattr_from_global(
             GlobalConfigs.PER_CONF.name,
             'DASHBOARD_DATE',
@@ -116,21 +115,9 @@ class DashboardViewSet(RetrieveModelMixin, GenericViewSet):
             project_id,
             default=['start'],
         )
-        self.payload_settings = ConfigServices.getattr_from_global(
-            GlobalConfigs.PER_CONF.name,
-            'DASHBOARD_PAYLOAD',
-            project_id,
-            default={},
-        )
-        self.formatting_settings = ConfigServices.getattr_from_global(
-            GlobalConfigs.PER_CONF.name,
-            'DASHBOARD_FORMATTING',
-            project_id,
-            default={'progress': 'percent'},
-        )
 
         # Initialize payload (remains in ViewSet - UI-specific)
-        self.payload(self.payload_settings)
+        self.payload(self.columns)
         self.errors = self.payload.errors
 
         return bool(not self.errors)
@@ -246,7 +233,7 @@ class DashboardPayload:
     handlers_available: typing.ClassVar['dict'] = {
         'go_run': 'Go to Run',
         'go_run_failed': 'Go to Run (Preview NOK)',
-        'go_tree': 'Go to Log',
+        'go_log': 'Go to Log',
         'go_bug': 'Go to Bug',
         'go_source': 'Go to Run Source',
         'go_report': 'Go to Report (Most Recent)',
@@ -257,31 +244,36 @@ class DashboardPayload:
         self.description = {}
         self.errors = []
 
-    def __call__(self, settings):
-        if not self.__match_settings_to_methods(settings.values()):
+    def __call__(self, columns):
+        if not self.__match_settings_to_methods(columns):
             return self.errors
 
-        self.__prepare_handlers(settings)
-        self.__prepare_payload_description(settings)
+        self.__prepare_handlers(columns)
+        self.__prepare_payload_description(columns)
 
         return self
 
-    def __match_settings_to_methods(self, settings):
+    def __match_settings_to_methods(self, columns):
         self.errors = []
-        diff = get_difference(settings, self.handlers_available.keys())
+        payloads = {column.get('payload') for column in columns.values() if 'payload' in column}
+        diff = get_difference(payloads, self.handlers_available.keys())
         if diff:
-            self.errors.append(f"Unknown value(s) in DASHBOARD_PAYLOAD: {', '.join(diff)}")
+            self.errors.append(
+                f"Unknown value(s) in DASHBOARD_COLUMNS payload: {', '.join(diff)}",
+            )
         return bool(not self.errors)
 
-    def __prepare_handlers(self, settings):
-        for key in settings:
-            method = getattr(self, settings[key])
-            self.handlers[key] = method
+    def __prepare_handlers(self, columns):
+        for key, col_settings in columns.items():
+            if 'payload' in col_settings:
+                method = getattr(self, col_settings['payload'])
+                self.handlers[key] = method
 
-    def __prepare_payload_description(self, settings):
+    def __prepare_payload_description(self, columns):
         self.description = {}
-        for key, payload in settings.items():
-            self.description[key] = self.handlers_available[payload]
+        for key, col_settings in columns.items():
+            if 'payload' in col_settings:
+                self.description[key] = self.handlers_available[col_settings['payload']]
 
     def go_run(self, data, run):
         for item in data:
@@ -308,7 +300,7 @@ class DashboardPayload:
             )
         return data
 
-    def go_tree(self, data, run):
+    def go_log(self, data, run):
         for item in data:
             item.update(
                 {


### PR DESCRIPTION
# Info
Refactors dashboard column configuration by merging separate `DASHBOARD_HEADER` and `DASHBOARD_PAYLOAD` keys into a single `DASHBOARD_COLUMNS` array of column objects, where each entry contains `key`, `label`, `payload`, and `formatting` as needed. This eliminates cross-key validation issues inherent to the config inheritance model and allows the schema to fully validate all column settings in one place.

The dashboard service is updated to consume the new format, and hardcoded payload handlers are replaced with values derived directly from the config schema.

A one-time migration step is included to bring all existing project configurations to the new format.

# Overview of Changes
## Config format
Before:
```
  "DASHBOARD_HEADER": [
    {
      "key": "status",
      "label": "Status"
    },
    {
      "key": "total",
      "label": "Total"
    },
    {
      "key": "unexpected",
      "label": "NOK"
    },
    {
      "key": "progress",
      "label": "Progress"
    },
    {
      "key": "notes",
      "label": "Notes"
    }
  ],
  "DASHBOARD_PAYLOAD": {
    "notes": "go_bug",
    "total": "go_tree",
    "unexpected": "go_run_failed"
  },
```

After:
```
  "DASHBOARD_COLUMNS": [
    {
      "key": "Status"
    },
    {
      "key": "total",
      "label": "Total",
      "payload": "go_log"
    },
    {
      "key": "unexpected",
      "label": "NOK",
      "payload": "go_run_failed"
    },
    {
      "key": "progress",
      "label": "Progress",
      "formatting": "percent"
    },
    {
      "key": "Notes",
      "payload": "go_bug"
    }
  ],
```

## Other changes
- Hardcoded payload handlers in the dashboard service are replaced with values derived from the config schema
- Payload value `go_tree` renamed to `go_log` to better reflect the target view name

# UI Requirements

When hovering over the `key` field in the config UI, the tooltip should display the field description ("Meta category name or built-in key") rather than the description of the matched const value (e.g. "Total number of tests"). Please investigate and fix the tooltip resolution logic for `anyOf` schemas.

# Deployment
`./scripts/deploy --steps per_project_conf run_services`