### PR TITLE
Add API v2 error response serializers

### DIFF
--- a/bublik/interfaces/api_v2/errors/serializers.py
+++ b/bublik/interfaces/api_v2/errors/serializers.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+from drf_spectacular.utils import PolymorphicProxySerializer
+from rest_framework import serializers
+
+
+class ErrorMessagesListResponseSerializer(serializers.Serializer):
+    messages = serializers.ListField(child=serializers.CharField())
+
+
+class ErrorMessagesByFieldResponseSerializer(serializers.Serializer):
+    messages = serializers.DictField(child=serializers.ListField(child=serializers.CharField()))
+
+
+ErrorResponseSerializer = PolymorphicProxySerializer(
+    component_name='ErrorResponse',
+    serializers=[
+        ErrorMessagesListResponseSerializer,
+        ErrorMessagesByFieldResponseSerializer,
+    ],
+    resource_type_field_name=None,
+)


### PR DESCRIPTION
## Info

This PR adds serializers for API v2 error responses. The serializers
describe common error payload shapes used by API endpoints and make them
available for OpenAPI schema documentation.

## Overview of changes

### Key Improvements

#### 1. Added error response serializers

Added serializers for the common API v2 error response formats:

- Error responses with a flat list of messages
- Error responses with field-specific validation messages

#### 2. Introduced a polymorphic error response schema

Added `ErrorResponseSerializer` based on `PolymorphicProxySerializer`.
It allows API documentation to represent multiple supported error
response shapes under a single `ErrorResponse` component.

#### 3. Prepared shared error schema location

Placed the serializers under:

`bublik/interfaces/api_v2/errors/serializers.py`

This keeps API v2 error documentation helpers separate from endpoint
implementation code and makes them reusable by API schema definitions.

## API

No runtime API behavior is changed.

This PR only adds serializers for documenting error responses in the
API v2 schema.

## UI Requirements

No UI changes.

## Deployment

No deployment steps are required.
