### PR TITLE
Pagination: fix OpenAPI schema mismatch for paginated responses

### DIFF
--- a/bublik/core/pagination.py
+++ b/bublik/core/pagination.py
@@ -30,3 +30,21 @@ class DefaultPageNumberPagination(PageNumberPagination):
                 ],
             ),
         )
+
+    def get_paginated_response_schema(self, schema):
+        return {
+            'type': 'object',
+            'required': ['pagination', 'results'],
+            'properties': {
+                'pagination': {
+                    'type': 'object',
+                    'required': ['count', 'next', 'previous'],
+                    'properties': {
+                        'count': {'type': 'integer', 'example': 123},
+                        'next': {'type': 'string', 'nullable': True, 'example': None},
+                        'previous': {'type': 'string', 'nullable': True, 'example': None},
+                    },
+                },
+                'results': schema,
+            },
+        }


### PR DESCRIPTION
Since the paginated response structure does not match the default pagination schema, define `get_paginated_response_schema()` in `DefaultPageNumberPagination` to make the generated OpenAPI schema reflect the actual response structure.