### PR TITLE
run: fix missing run stats test comments

### DIFF
--- a/bublik/core/run/stats.py
+++ b/bublik/core/run/stats.py
@@ -220,7 +220,7 @@ def add_comments(node, tests_comments):
     The order of comments is determined by the serial value.
     '''
     if node:
-        node['comments'] = tests_comments.get(node['result_id'], [])
+        node['comments'] = tests_comments.get(node['test_id'], [])
         node['comments'] = [
             json.loads(comment) if isinstance(comment, str) else comment
             for comment in node['comments']


### PR DESCRIPTION
Use `node["test_id"]` when attaching MetaTest comments to run stats nodes.
PR #302 changed stats node fields so `result_id `now identifies the test iteration result and `test_id` identifies the test. Test comments are keyed by test ID, so using `result_id` caused comments to be missed.