### PR TITLE
Management: fix per_conf migration for dashboard settings

### DIFF
--- a/bublik/core/config/reformatting/steps.py
+++ b/bublik/core/config/reformatting/steps.py
@@ -425,6 +425,7 @@ class MergeDashboardSettings(BaseReformatStep):
             config.project,
             default={'total': 'go_tree', 'unexpected': 'go_run_failed', 'notes': 'go_bug'},
         )
+        db_runs_sort = config.content.get('DASHBOARD_RUNS_SORT')
 
         schema = ConfigServices.get_schema(
             ConfigTypes.GLOBAL,
@@ -450,9 +451,16 @@ class MergeDashboardSettings(BaseReformatStep):
                     payload = 'go_log'
                 db_header_col['payload'] = payload
             if db_header_col['key'] not in builtin_column_keys:
-                db_header_col['key'] = db_header_col.pop('label')
+                db_key = db_header_col.pop('key')
+                db_label = db_header_col.pop('label')
+                db_header_col['key'] = db_label
+                if db_runs_sort and db_key in db_runs_sort:
+                    db_runs_sort = [db_label if k == db_key else k for k in db_runs_sort]
             db_columns.append(db_header_col)
 
         config.content['DASHBOARD_COLUMNS'] = db_columns
+
+        if db_runs_sort is not None:
+            config.content['DASHBOARD_RUNS_SORT'] = db_runs_sort
 
         return config

--- a/bublik/core/config/reformatting/steps.py
+++ b/bublik/core/config/reformatting/steps.py
@@ -396,6 +396,59 @@ class AllowMultipleSeriesArgs(BaseReformatStep):
 
 
 class MergeDashboardSettings(BaseReformatStep):
+    '''
+    Reformat passed global per_conf config content:
+     - merge DASHBOARD_HEADER and DASHBOARD_PAYLOAD into DASHBOARD_COLUMNS,
+     - for non-builtin column keys replace the key with the label value,
+     - update DASHBOARD_RUNS_SORT keys accordingly.
+
+    Example:
+    "DASHBOARD_HEADER": [
+        {
+            "key": "session",
+            "label": "Session"
+        },
+        {
+            "key": "status",
+            "label": "Status"
+        },
+        {
+            "key": "total",
+            "label": "Total"
+        },
+        {
+            "key": "progress",
+            "label": "Progress"
+        }
+    ],
+    "DASHBOARD_PAYLOAD": {
+        "session": "go_run",
+        "total": "go_tree"
+    },
+    "DASHBOARD_RUNS_SORT": ["session", "start"]
+    ->
+    "DASHBOARD_COLUMNS": [
+        {
+            "key": "Session",
+            "payload": "go_run"
+        },
+        {
+            "key": "Status"
+        },
+        {
+            "key": "total",
+            "label": "Total",
+            "payload": "go_log"
+        },
+        {
+            "key": "progress",
+            "label": "Progress",
+            "formatting": "percent"
+        }
+    ],
+    "DASHBOARD_RUNS_SORT": ["Session", "start"]
+    '''
+
     def applied(self, config, **kwargs):
         content = config.content
         return not any(

--- a/bublik/core/config/reformatting/steps.py
+++ b/bublik/core/config/reformatting/steps.py
@@ -409,6 +409,13 @@ class MergeDashboardSettings(BaseReformatStep):
             GlobalConfigs.PER_CONF.name,
             'DASHBOARD_HEADER',
             config.project,
+            default=[
+                {'key': 'status', 'label': 'Status'},
+                {'key': 'total', 'label': 'Total'},
+                {'key': 'unexpected', 'label': 'NOK'},
+                {'key': 'progress', 'label': 'Progress'},
+                {'key': 'notes', 'label': 'Notes'},
+            ],
         )
         db_payload = config.content.get(
             'DASHBOARD_PAYLOAD',
@@ -416,6 +423,7 @@ class MergeDashboardSettings(BaseReformatStep):
             GlobalConfigs.PER_CONF.name,
             'DASHBOARD_PAYLOAD',
             config.project,
+            default={'total': 'go_tree', 'unexpected': 'go_run_failed', 'notes': 'go_bug'},
         )
 
         schema = ConfigServices.get_schema(


### PR DESCRIPTION
Fix the main project config reformatting step that merges `DASHBOARD_HEADER` and `DASHBOARD_PAYLOAD` into `DASHBOARD_COLUMNS`:
- Provide explicit fallback defaults to avoid `KeyError` when `DASHBOARD_HEADER` and/or `DASHBOARD_PAYLOAD` keys are missing in default configs
- Sync dashboard sort keys with the updated column key structure after migration
- Add docstring to the migration step