### PR TITLE
Importruns: fix possible hanging on arbitrary URL and improve parameter validation

### DIFF
--- a/bublik/core/exceptions.py
+++ b/bublik/core/exceptions.py
@@ -33,7 +33,11 @@ def custom_exception_handler(exc, context):
     # to get the standard error response.
     response = exception_handler(exc, context)
 
-    if response is None or getattr(exc, '__cause__', None):
+    if (
+        response is None
+        or getattr(exc, '__cause__', None)
+        or (isinstance(exc, BublikError) and exc.debug_details)
+    ):
         logger.error('Exception occurred:', exc_info=exc)
 
     if response is None:

--- a/bublik/core/importruns/utils.py
+++ b/bublik/core/importruns/utils.py
@@ -1,18 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
-from argparse import ArgumentTypeError
+from __future__ import annotations
+
 from datetime import datetime
 
 from django.core.files import locks
-import pendulum
 
-from bublik.core.argparse import (
-    parser_type_date,
-    parser_type_force,
-    parser_type_url,
-)
-from bublik.core.exceptions import ImportrunsError
 from bublik.core.logging import get_task_or_server_logger
 
 
@@ -66,35 +60,3 @@ def measure_time(prefix: str = ''):
 
 def runtime(start_time):
     return (datetime.now() - start_time).total_seconds()
-
-
-def normalize_importruns_params(
-    run_source_url,
-    project_name=None,
-    date_from=None,
-    date_to=None,
-    force=None,
-):
-    date_from = (
-        parser_type_date(date_from.replace('-', '.')) if date_from is not None else datetime.min
-    )
-    date_from = pendulum.instance(datetime.combine(date_from, datetime.min.time()))
-
-    date_to = (
-        parser_type_date(date_to.replace('-', '.')) if date_to is not None else datetime.max
-    )
-    date_to = pendulum.instance(datetime.combine(date_to, datetime.max.time()))
-
-    try:
-        return {
-            'run_source_url': parser_type_url(run_source_url),
-            'project_name': project_name,
-            'date_from': date_from,
-            'date_to': date_to,
-            'force': parser_type_force(force) if force is not None else False,
-        }
-
-    except ArgumentTypeError as exc:
-        raise ImportrunsError(
-            message='invalid parameters for importruns command',
-        ) from exc

--- a/bublik/interfaces/api_v2/__init__.py
+++ b/bublik/interfaces/api_v2/__init__.py
@@ -20,7 +20,7 @@ from .dashboard import (
 )
 from .eventlog.views import ImportEventViewSet
 from .history import HistoryViewSet
-from .importruns import ImportrunsViewSet
+from .importruns.views import ImportrunsViewSet
 from .index import render_docs, render_react
 from .job_task.views import JobTaskExecutionViewSet
 from .log import LogViewSet

--- a/bublik/interfaces/api_v2/importruns.py
+++ b/bublik/interfaces/api_v2/importruns.py
@@ -36,9 +36,6 @@ class ImportrunsViewSet(ViewSet):
         '''
         Creates a Celery task to import a session from the provided URI.
         '''
-
-        requesting_host = get_current_scheme_host_prefix(request)
-
         url = request.query_params.get('url')
         import_job = create_import_job(url)
 
@@ -57,7 +54,7 @@ class ImportrunsViewSet(ViewSet):
             # Schedule Celery tasks
             tasks_data = schedule_runs(
                 request=request,
-                requesting_host=requesting_host,
+                requesting_host=get_current_scheme_host_prefix(request),
                 job_id=import_job.id,
                 **importruns_params,
             )

--- a/bublik/interfaces/api_v2/importruns/serializers.py
+++ b/bublik/interfaces/api_v2/importruns/serializers.py
@@ -11,7 +11,8 @@ from bublik.core.argparse import (
     parser_type_date,
     parser_type_force,
 )
-from bublik.data.models import Project
+from bublik.core.config.services import ConfigServices
+from bublik.data.models import GlobalConfigs, Project
 
 
 class ImportrunsSerializer(serializers.Serializer):
@@ -28,6 +29,30 @@ class ImportrunsSerializer(serializers.Serializer):
         if 'to' in data:
             data['date_to'] = data.pop('to')[0]
         return super().to_internal_value(data)
+
+    def validate_url(self, url):
+        project_id = self.initial_data.get('project')
+        project_ids = (
+            Project.objects.filter(id=project_id)
+            if project_id is not None
+            else Project.objects.all()
+        ).values_list('id', flat=True)
+
+        allowed_uris = set()
+        for pid in project_ids:
+            logs_bases = ConfigServices.getattr_from_global(
+                GlobalConfigs.REFERENCES.name,
+                'LOGS_BASES',
+                pid,
+            )
+            for logs_base in logs_bases:
+                allowed_uris.update(logs_base.get('uri', []))
+
+        if not any(url.startswith(uri) for uri in allowed_uris):
+            msg = 'URL does not match any allowed logs base URI'
+            raise serializers.ValidationError(msg)
+
+        return url
 
     def validate_date_from(self, date_from):
         try:

--- a/bublik/interfaces/api_v2/importruns/serializers.py
+++ b/bublik/interfaces/api_v2/importruns/serializers.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+from __future__ import annotations
+
+from argparse import ArgumentTypeError
+
+from rest_framework import serializers
+
+from bublik.core.argparse import (
+    parser_type_date,
+    parser_type_force,
+)
+from bublik.data.models import Project
+
+
+class ImportrunsSerializer(serializers.Serializer):
+    url = serializers.URLField()
+    project = serializers.IntegerField(required=False, allow_null=True)
+    date_from = serializers.CharField(required=False, allow_null=True)
+    date_to = serializers.CharField(required=False, allow_null=True)
+    force = serializers.CharField(required=False, allow_null=True)
+
+    def to_internal_value(self, data):
+        data = data.copy()
+        if 'from' in data:
+            data['date_from'] = data.pop('from')[0]
+        if 'to' in data:
+            data['date_to'] = data.pop('to')[0]
+        return super().to_internal_value(data)
+
+    def validate_date_from(self, date_from):
+        try:
+            return parser_type_date(date_from.replace('-', '.')) if date_from else None
+        except ArgumentTypeError as ate:
+            raise serializers.ValidationError(ate) from None
+
+    def validate_date_to(self, date_to):
+        try:
+            return parser_type_date(date_to.replace('-', '.')) if date_to is not None else None
+        except ArgumentTypeError as ate:
+            raise serializers.ValidationError(ate) from None
+
+    def validate_force(self, force):
+        try:
+            return parser_type_force(force) if force is not None else False
+        except ArgumentTypeError as ate:
+            raise serializers.ValidationError(ate) from None
+
+    def to_importruns_params(self):
+        data = self.validated_data
+        return {
+            'url': data['url'],
+            'project_name': (
+                Project.objects.get(id=data['project']).name
+                if data.get('project') is not None
+                else None
+            ),
+            'date_from': (
+                data['date_from'].replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
+                if data.get('date_from')
+                else None
+            ),
+            'date_to': (
+                data['date_to']
+                .replace(hour=23, minute=59, second=59, microsecond=0)
+                .isoformat()
+                if data.get('date_to')
+                else None
+            ),
+            'force': data.get('force', False),
+        }

--- a/bublik/interfaces/api_v2/importruns/views.py
+++ b/bublik/interfaces/api_v2/importruns/views.py
@@ -19,7 +19,7 @@ from bublik.core.importruns.source.run_traversal import schedule_runs
 from bublik.core.logging import get_task_or_server_logger
 from bublik.core.shortcuts import get_current_scheme_host_prefix
 from bublik.core.utils import create_import_job, get_local_log
-from bublik.data.models import Project
+from bublik.interfaces.api_v2.importruns.serializers import ImportrunsSerializer
 
 
 logger = get_task_or_server_logger()
@@ -36,27 +36,19 @@ class ImportrunsViewSet(ViewSet):
         '''
         Creates a Celery task to import a session from the provided URI.
         '''
-        url = request.query_params.get('url')
+        serializer = ImportrunsSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+
+        url = serializer.validated_data['url']
         import_job = create_import_job(url)
 
         try:
-            project_id = request.query_params.get('project')
-            importruns_params = {
-                'url': url,
-                'project_name': (
-                    Project.objects.get(id=project_id).name if project_id is not None else None
-                ),
-                'date_from': request.query_params.get('from'),
-                'date_to': request.query_params.get('to'),
-                'force': request.query_params.get('force'),
-            }
-
             # Schedule Celery tasks
             tasks_data = schedule_runs(
                 request=request,
                 requesting_host=get_current_scheme_host_prefix(request),
                 job_id=import_job.id,
-                **importruns_params,
+                **serializer.to_importruns_params(),
             )
 
             return Response(

--- a/bublik/interfaces/celery/tasks.py
+++ b/bublik/interfaces/celery/tasks.py
@@ -15,9 +15,9 @@ from celery.signals import (
     task_success,
 )
 from django.core.management import call_command
+import pendulum
 
 from bublik import settings
-from bublik.core.importruns.utils import normalize_importruns_params
 from bublik.core.logging import get_task_or_server_logger, parse_log
 from bublik.core.mail import send_importruns_failed_mail
 from bublik.core.utils import create_event, get_import_job_task
@@ -195,18 +195,42 @@ def importruns(
         logger.info(f'[URL]:  {run_source_url}')
         logger.info(f'[RUN]:  curl {query_url}')
 
-        importruns_params = normalize_importruns_params(
-            run_source_url=run_source_url,
-            project_name=project_name,
-            date_from=date_from,
-            date_to=date_to,
-            force=force,
-        )
-
         import_run(
             job_id=job_id,
             task_id=task_id,
-            **importruns_params,
+            run_source_url=run_source_url,
+            project_name=project_name,
+            date_from=(
+                pendulum.instance(
+                    datetime.combine(
+                        pendulum.parse(date_from).date(),
+                        datetime.min.time(),
+                    ),
+                )
+                if date_from
+                else pendulum.instance(
+                    datetime.combine(
+                        datetime.min.date(),
+                        datetime.min.time(),
+                    ),
+                )
+            ),
+            date_to=(
+                pendulum.instance(
+                    datetime.combine(
+                        pendulum.parse(date_to).date(),
+                        datetime.max.time(),
+                    ),
+                )
+                if date_to
+                else pendulum.instance(
+                    datetime.combine(
+                        datetime.max.date(),
+                        datetime.max.time(),
+                    ),
+                )
+            ),
+            force=force,
         )
 
         return task_id


### PR DESCRIPTION
Previously, providing an arbitrary URL to the import endpoint could cause the server to hang indefinitely during directory traversal. This PR fixes that by validating the URL upfront against the configured logs base URIs before any processing begins.

Additionally, import parameter validation and normalization are moved into a serializer, so that invalid input is rejected at the entry point with errors attributed to specific fields. As a side effect, additional error context is now always logged when provided, instead of being hidden in some cases.