### PR TITLE
Importruns: fix authentication failures when accessing the logs server

### DIFF
--- a/templates/bublik-gunicorn.service.template
+++ b/templates/bublik-gunicorn.service.template
@@ -7,7 +7,7 @@ WorkingDirectory=${BUBLIK_SRC}
 ExecStart=${SCRIPTS_DIR}/rungunicorn
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
-PrivateTmp=true
+PrivateTmp=false
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Fix authentication failures when accessing the logs server by disabling PrivateTmp in the gunicorn service template, which was isolating /tmp and hiding the Kerberos ticket cache from the process.