### PR TITLE
History: include report config ID in test result response

### DIFF
--- a/bublik/core/history/v2/utils.py
+++ b/bublik/core/history/v2/utils.py
@@ -10,6 +10,7 @@ from deepdiff import DeepHash
 from django.conf import settings
 
 from bublik.core.datetime_formatting import get_duration
+from bublik.core.report.services import ReportService
 from bublik.core.run.stats import get_expected_results
 from bublik.core.run.utils import prepare_dates_period
 from bublik.core.utils import key_value_dict_transforming
@@ -45,7 +46,7 @@ def prepare_list_results(
         result_finish = test_result['finish']
 
         # Handle expected result
-        test_result_obj = TestIterationResult.objects.select_related('project').get(
+        test_result_obj = TestIterationResult.objects.select_related('project', 'test_run').get(
             id=result_id,
         )
         expected_results_data = get_expected_results(test_result_obj)
@@ -79,6 +80,9 @@ def prepare_list_results(
             'project_name': test_result_obj.project.name,
             'result_id': result_id,
             'iteration_id': iteration_id,
+            'report_config_id': ReportService.get_most_recent_config_for_run_report(
+                test_result_obj.test_run,
+            ),
         }
 
         results_to_response.append(result)

--- a/bublik/core/report/services.py
+++ b/bublik/core/report/services.py
@@ -181,6 +181,25 @@ class ReportService:
         return run_report_configs
 
     @staticmethod
+    def get_most_recent_config_for_run_report(run) -> list[dict]:
+        '''
+        Get the ID of the most recent available report configuration for a run.
+
+        Args:
+            run: TestIterationResult instance
+
+        Returns:
+            ID of the most recent report config if available,
+            otherwise None if no configs exist.
+        '''
+
+        run_report_configs_data = ReportService.get_configs_for_run_report(run)
+        if run_report_configs_data:
+            # get the ID of the most recent applicable config
+            return max(run_report_configs_data, key=lambda cfg_data: cfg_data['id'])['id']
+        return None
+
+    @staticmethod
     def generate_report(run_id: int, config_id: int) -> dict:
         '''
         Generate full report for a run using specified config.

--- a/bublik/interfaces/api_v2/dashboard.py
+++ b/bublik/interfaces/api_v2/dashboard.py
@@ -328,10 +328,8 @@ class DashboardPayload:
             )
 
     def go_report(self, data, run):
-        run_report_configs_data = ReportService.get_configs_for_run_report(run)
-        if run_report_configs_data:
-            # get the ID of the most recent applicable config
-            cfg_id = max(run_report_configs_data, key=lambda cfg_data: cfg_data['id'])['id']
+        cfg_id = ReportService.get_most_recent_config_for_run_report(run)
+        if cfg_id:
             for item in data:
                 item.update(
                     {


### PR DESCRIPTION
# Info

Add the most recent applicable report configuration ID to each test result entry returned by the history API. This allows the UI to use it for navigation to the corresponding report.

# Overview of changes
## API
### GET /bublik/api/v2/history/
Response data example:
```
{
    "from_date": "2026-02-22",
    "to_date": "2026-05-25",
    "counts": {
        "runs": 2,
        "iterations": 1,
        "total_results": 2,
        "expected_results": 2,
        "unexpected_results": 0
    },
    "pagination": {
        "count": 2,
        "next": null,
        "previous": null
    },
    "results": [
        {
            "start_date": "2026-05-24T21:30:40.947000+00:00",
            "finish_date": "2026-05-24T21:30:41.643000+00:00",
            "duration": "0:00:00.696",
            "obtained_result": {
                "result_type": "PASSED",
                "verdicts": []
            },
            "expected_results": [
                {
                    "result_type": "PASSED",
                    "verdicts": [],
                    "keys": []
                }
            ],
            "important_tags": [
                "net_virtio",
                "pci-1af4-1000",
                "peer-qemu-virtio-net",
                "qemu-virtio-net",
                "linux-mm=612",
                "uio_pci_generic"
            ],
            "relevant_tags": [
                "dpdk=26070000",
                "dpdk-26.07.0-rc0",
                "kernel-linux",
                "max_rx_queues=1",
                "max_tx_queues=1",
                "pci-1af4"
            ],
            "metadata": [
                "CFG=virtio_virtio:dain",
                "TS_NAME=dpdk-ethdev-ts",
                "USER=cbs-speed-stack"
            ],
            "parameters": [
                "env=VAR.env.peer2peer",
                "nb_pkts=1",
                "payload_len=512",
                "tmpl=VAR.tmpl.iut2tst.eth"
            ],
            "has_error": false,
            "has_measurements": false,
            "run_id": 1,
            "project_id": 2,
            "project_name": "tsf/dpdk-ethdev",
            "result_id": 5,
            "iteration_id": 4,
            "report_config_id": 11
        },
        ...
```

# UI Requirements

See "Overview of changes > API"

# Deployment
```
./scripts/deploy --steps run_services
```