### PR TITLE
mcp: fix run listing and JSON log compatibility

### DIFF
--- a/bublik/core/log/services.py
+++ b/bublik/core/log/services.py
@@ -13,6 +13,7 @@ from rest_framework.exceptions import ValidationError
 from bublik.core.exceptions import BadGatewayError, UnprocessableEntityError
 from bublik.core.result.services import ResultService
 from bublik.core.run.external_links import get_result_log, get_sources
+from bublik.core.url import get_url
 
 
 class LogService:
@@ -114,8 +115,9 @@ class LogService:
             raise UnprocessableEntityError(msg)
 
         try:
-            response = requests.get(url, timeout=30)
-            response.raise_for_status()
+            response = get_url(url, quiet_404=allow_not_found, timeout=30)
+            if response is None:
+                return None
             return response.json()
         except requests.exceptions.HTTPError as re:
             if (

--- a/bublik/core/run/services.py
+++ b/bublik/core/run/services.py
@@ -13,6 +13,7 @@ from django.db.models import Count, Q
 from rest_framework.exceptions import ValidationError
 
 from bublik.core.config.services import ConfigServices
+from bublik.core.datetime_formatting import date_str_to_db
 from bublik.core.exceptions import NotFoundError
 from bublik.core.pagination_helpers import PaginatedResult
 from bublik.core.run.compromised import (
@@ -474,6 +475,37 @@ class RunService:
             )
 
         return {'buckets': buckets}
+
+    @staticmethod
+    def list_runs_by_dashboard_date_queryset(date: str, project_id: int | None = None):
+        '''
+        Get runs for a dashboard date using the same date source as dashboard data.
+
+        Some installations configure dashboard dates through run metadata instead of
+        the run start timestamp.
+        '''
+        date_meta = ConfigServices.getattr_from_global(
+            models.GlobalConfigs.PER_CONF.name,
+            'DASHBOARD_DATE',
+            project_id,
+        )
+
+        if date_meta:
+            queryset = models.TestIterationResult.objects.filter(
+                test_run__isnull=True,
+                meta_results__meta__name=date_meta,
+                meta_results__meta__value=date,
+            )
+        else:
+            queryset = models.TestIterationResult.objects.filter(
+                test_run__isnull=True,
+                start__date=date_str_to_db(date),
+            )
+
+        if project_id:
+            queryset = queryset.filter(project_id=project_id)
+
+        return queryset.select_related('project').distinct().order_by('-start')
 
     @staticmethod
     def get_run_requirements(run_id: int) -> list[str]:

--- a/bublik/core/url.py
+++ b/bublik/core/url.py
@@ -13,16 +13,20 @@ from bublik.core.logging import get_task_or_server_logger
 SAVE_URL_CHUNK_SIZE = 16384
 
 
-def get_url(url_str, raise_for_status=True, quiet_404=False):
+def get_url(url_str, raise_for_status=True, quiet_404=False, timeout=None):
     kerberos_auth = HTTPKerberosAuth(mutual_authentication=DISABLED)
-    req = requests.get(url_str, auth=kerberos_auth)
+    request_kwargs = {'auth': kerberos_auth}
+    if timeout is not None:
+        request_kwargs['timeout'] = timeout
+
+    req = requests.get(url_str, **request_kwargs)
 
     # CGI uses 302 status code for auto generated files and
     # requests lib doesn't authenticate on retry.
     # Do retry here when auto generated file is in place.
     not_auth = 401
     if req.status_code == not_auth:
-        req = requests.get(url_str, auth=kerberos_auth)
+        req = requests.get(url_str, **request_kwargs)
 
     if raise_for_status:
         not_found_code = 404

--- a/bublik/mcp/models.py
+++ b/bublik/mcp/models.py
@@ -214,8 +214,13 @@ class LogContentSnifferPacket(BaseModel):
 
 
 class TimeStamp(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
     timestamp: float = Field(..., description='Timestamp in seconds')
     formatted: str = Field(..., description='Formatted timestamp')
+
+
+LogTimestamp = TimeStamp | float
 
 
 LogContent = (
@@ -234,7 +239,7 @@ class LogTableData(BaseModel):
     level: LogLevelSchema
     entity_name: str
     user_name: str
-    timestamp: TimeStamp
+    timestamp: LogTimestamp
     log_content: list[LogContent] = Field(
         ...,
         description='Log content accepts series of blocks for displaying data',

--- a/bublik/mcp/processor.py
+++ b/bublik/mcp/processor.py
@@ -8,6 +8,7 @@ Log processor for working with validated JsonLog data.
 from __future__ import annotations
 
 from collections import Counter
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, ClassVar
 
 from bublik.mcp.models import (
@@ -21,7 +22,24 @@ from bublik.mcp.models import (
 
 
 if TYPE_CHECKING:
-    from bublik.mcp.models import LogTableData, SnifferContentItem
+    from bublik.mcp.models import LogTableData, LogTimestamp, SnifferContentItem
+
+
+def get_log_timestamp_seconds(timestamp: LogTimestamp) -> float:
+    '''
+    Get Unix timestamp seconds from legacy and numeric JSON log timestamp shapes.
+    '''
+    return timestamp if isinstance(timestamp, float) else timestamp.timestamp
+
+
+def get_log_timestamp_display(timestamp: LogTimestamp) -> str:
+    '''
+    Get formatted display time from legacy and numeric JSON log timestamp shapes.
+    '''
+    if not isinstance(timestamp, float):
+        return timestamp.formatted
+
+    return datetime.fromtimestamp(timestamp, timezone.utc).strftime('%H:%M:%S.%f')[:-3]
 
 
 class LogProcessor:
@@ -524,8 +542,8 @@ class LogProcessor:
                 level=str(level),
                 entity_name=item.entity_name,
                 user_name=item.user_name,
-                timestamp=item.timestamp.formatted,
-                timestamp_raw=item.timestamp.timestamp,
+                timestamp=get_log_timestamp_display(item.timestamp),
+                timestamp_raw=get_log_timestamp_seconds(item.timestamp),
                 content=self._extract_content(item.log_content),
                 content_type=self._get_content_type(item.log_content),
                 depth=depth,

--- a/bublik/mcp/tests/test_log_timestamp_schema.py
+++ b/bublik/mcp/tests/test_log_timestamp_schema.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+
+from pydantic import ValidationError
+import pytest
+
+from bublik.mcp.models import JsonLog, TimeStamp
+from bublik.mcp.processor import LogProcessor
+from bublik.mcp.tests.conftest import EXAMPLES_DIR
+
+
+NUMERIC_TIMESTAMP = 1705312800.0
+FORMATTED_NUMERIC_TIMESTAMP = '10:00:00.000'
+
+
+def _load_example_data() -> dict:
+    with open(EXAMPLES_DIR / 'comprehensive.json') as f:
+        return json.load(f)
+
+
+def _first_log_line(data: dict) -> dict:
+    return data['root'][0]['content'][2]['data'][0]
+
+
+def test_json_log_accepts_legacy_timestamp_object():
+    timestamp = {'timestamp': 1711228667.618432, 'formatted': '21:17:47.618'}
+
+    assert TimeStamp.model_validate(timestamp).timestamp == timestamp['timestamp']
+
+
+def test_json_log_accepts_numeric_timestamp():
+    data = _load_example_data()
+    line = _first_log_line(data)
+    line['timestamp'] = NUMERIC_TIMESTAMP
+
+    log = JsonLog.model_validate(data)
+    processor = LogProcessor(log)
+    first_line = processor.flat_lines[0]
+
+    assert first_line.timestamp_raw == NUMERIC_TIMESTAMP
+    assert first_line.timestamp == FORMATTED_NUMERIC_TIMESTAMP
+
+
+def test_json_log_rejects_legacy_timestamp_object_without_formatted():
+    data = _load_example_data()
+    line = _first_log_line(data)
+    timestamp = deepcopy(line['timestamp'])
+    del timestamp['formatted']
+    line['timestamp'] = timestamp
+
+    with pytest.raises(ValidationError):
+        JsonLog.model_validate(data)

--- a/bublik/mcp/tools.py
+++ b/bublik/mcp/tools.py
@@ -218,7 +218,7 @@ def register_tools(mcp: FastMCP):  # noqa: C901
         finish_date: str | None = None,
         project_id: int | None = None,
         run_status: str | None = None,
-        run_data: str | None = None,
+        run_metas: str | None = None,
         tag_expr: str | None = None,
         label_expr: str | None = None,
         revision_expr: str | None = None,
@@ -234,7 +234,7 @@ def register_tools(mcp: FastMCP):  # noqa: C901
             finish_date: Finish date in yyyy-mm-dd format (e.g., '2024-01-31')
             project_id: Optional project ID to filter results
             run_status: Optional run status filter
-            run_data: Semicolon-separated metadata (tags, labels, revisions, branches)
+            run_metas: Semicolon-separated metadata (tags, labels, revisions, branches)
             tag_expr: Tag expression filter (supports boolean logic: &, |, !)
             label_expr: Label expression filter (supports boolean logic: &, |, !)
             revision_expr: Revision expression filter (supports boolean logic: &, |, !)
@@ -250,7 +250,7 @@ def register_tools(mcp: FastMCP):  # noqa: C901
             finish_date=finish_date,
             project_id=project_id,
             run_status=run_status,
-            run_data=run_data,
+            run_metas=run_metas,
             tag_expr=tag_expr,
             label_expr=label_expr,
             revision_expr=revision_expr,

--- a/bublik/mcp/tools.py
+++ b/bublik/mcp/tools.py
@@ -280,13 +280,18 @@ def register_tools(mcp: FastMCP):  # noqa: C901
         Returns:
             Dictionary with pagination metadata and today's run details
         '''
-        today = date.today().isoformat()
-        queryset = await sync_to_async(RunService.list_runs_queryset)(
-            start_date=today,
-            finish_date=today,
+        date_str = await sync_to_async(DashboardService.get_latest_dashboard_date)(
             project_id=project_id,
         )
-        runs_details = await sync_to_async(generate_runs_details)(queryset)
+        queryset = (
+            await sync_to_async(RunService.list_runs_by_dashboard_date_queryset)(
+                date=date_str,
+                project_id=project_id,
+            )
+            if date_str
+            else []
+        )
+        runs_details = await sync_to_async(generate_runs_details)(queryset) if date_str else []
         return await sync_to_async(PaginatedResult.paginate_queryset)(
             runs_details,
             page,


### PR DESCRIPTION
## Summary

Fix several Bublik MCP tool failures reported in #317 and align MCP log parsing with the JSON log schema change from

## Changes

- Fix `list_runs` by passing MCP `run_data` to `RunService.list_runs_queryset()` as `run_metas`.
- Make `list_runs_today` use the latest dashboard date instead of the MCP server wall-clock date.
- Add dashboard-date-based run querying so MCP results match dashboard rows when `DASHBOARD_DATE` metadata is configured.
- Fetch JSON logs through the shared authenticated URL helper with timeout support.
- Support both JSON log timestamp shapes:
  - legacy `{ "timestamp": ..., "formatted": ... }`
  - new numeric `timestamp`