### PR TITLE
Importruns: fix timezone mismatch between run and iteration timestamps

### DIFF
--- a/bublik/core/datetime_formatting.py
+++ b/bublik/core/datetime_formatting.py
@@ -2,9 +2,11 @@
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
 from datetime import datetime
+from functools import lru_cache
 
 from django.conf import settings
 from django.utils import timezone
+import pendulum
 import pytz
 
 
@@ -63,6 +65,15 @@ def get_duration(dt_start, dt_finish):
 
 def utc_ts_to_dt(ts):
     return datetime.fromtimestamp(ts, timezone.get_current_timezone())
+
+
+@lru_cache(maxsize=1)
+def get_run_tz(run):
+    start_timestamp = run.meta_results.get(meta__name='START_TIMESTAMP').meta.value
+    start_timestamp_offset = pendulum.parse(start_timestamp).utcoffset()
+    return (
+        timezone(start_timestamp_offset) if start_timestamp_offset is not None else timezone.utc
+    )
 
 
 def localize_date(date):

--- a/bublik/core/datetime_formatting.py
+++ b/bublik/core/datetime_formatting.py
@@ -63,8 +63,10 @@ def get_duration(dt_start, dt_finish):
     return str(dt_finish - dt_start)[:-3]
 
 
-def utc_ts_to_dt(ts):
-    return datetime.fromtimestamp(ts, timezone.get_current_timezone())
+def utc_ts_to_dt(ts, tz=None):
+    if tz is None:
+        tz = timezone.get_current_timezone()
+    return datetime.fromtimestamp(ts, tz)
 
 
 @lru_cache(maxsize=1)

--- a/bublik/core/importruns/source/execution.py
+++ b/bublik/core/importruns/source/execution.py
@@ -7,7 +7,7 @@ from datetime import timezone
 from django.core.management import call_command
 from django.db import transaction
 
-from bublik.core.datetime_formatting import get_run_tz, to_db_format
+from bublik.core.datetime_formatting import get_run_tz, to_db_format, utc_ts_to_dt
 from bublik.core.importruns import ImportMode, identify_run
 from bublik.core.importruns.live.plan_tracking import PlanItem
 from bublik.core.importruns.milog import EntryLevel, HandlerArtifacts
@@ -74,11 +74,13 @@ def handle_iteration(
 
     start_ts, end_ts = (
         (
-            to_db_format(data[local_ts_key])
+            utc_ts_to_dt(data[utc_ts_key], timezone.utc)
+            if utc_ts_key in data
+            else to_db_format(data[local_ts_key])
             .replace(tzinfo=get_run_tz(run))
             .astimezone(timezone.utc)
         )
-        for local_ts_key in ['start_ts', 'end_ts']
+        for utc_ts_key, local_ts_key in [('start_ts_utc', 'start_ts'), ('end_ts_utc', 'end_ts')]
     )
 
     iteration_result = add_iteration_result(

--- a/bublik/core/importruns/source/execution.py
+++ b/bublik/core/importruns/source/execution.py
@@ -2,10 +2,12 @@
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
 from collections import Counter
+from datetime import timezone
 
 from django.core.management import call_command
 from django.db import transaction
 
+from bublik.core.datetime_formatting import get_run_tz, to_db_format
 from bublik.core.importruns import ImportMode, identify_run
 from bublik.core.importruns.live.plan_tracking import PlanItem
 from bublik.core.importruns.milog import EntryLevel, HandlerArtifacts
@@ -70,10 +72,19 @@ def handle_iteration(
     )
     handle_iteration.counter['created_iter_obj'] += add_iteration.counter['created']
 
+    start_ts, end_ts = (
+        (
+            to_db_format(data[local_ts_key])
+            .replace(tzinfo=get_run_tz(run))
+            .astimezone(timezone.utc)
+        )
+        for local_ts_key in ['start_ts', 'end_ts']
+    )
+
     iteration_result = add_iteration_result(
         project_id,
-        data['start_ts'],
-        data['end_ts'],
+        start_ts,
+        end_ts,
         iteration,
         run,
         parent_package,

--- a/bublik/core/run/metadata.py
+++ b/bublik/core/run/metadata.py
@@ -185,11 +185,11 @@ class MetaData:
     def __parse_timestamps(self):
         start_meta = find_dict_in_list({'name': 'START_TIMESTAMP'}, self.metas)
         if start_meta and 'value' in start_meta:
-            self.run_start = pendulum.parse(start_meta['value'])
+            self.run_start = pendulum.parse(start_meta['value']).in_timezone('UTC')
 
         finish_meta = find_dict_in_list({'name': 'FINISH_TIMESTAMP'}, self.metas)
         if finish_meta and 'value' in finish_meta:
-            self.run_finish = pendulum.parse(finish_meta['value'])
+            self.run_finish = pendulum.parse(finish_meta['value']).in_timezone('UTC')
 
     def check_run_period(self, date_from, date_to):
         return not (


### PR DESCRIPTION
Run timestamps typically carry explicit timezone info, while iteration timestamps are naive strings that get localized using Django's `TIME_ZONE` setting. When these timezones differ, this leads to a shift between run and iteration times.

Fix this by assigning the run's timezone to iteration timestamps, derived from the `START_TIMESTAMP` meta, which ensures consistency. Additionally, all timestamps are explicitly converted to UTC.

When available, Unix timestamps are used instead of naive strings for iteration timestamps.