### PR TITLE
run/results: split API modules and introduce DTO-based service contracts

### DIFF
--- a/bublik/core/run/dto.py
+++ b/bublik/core/run/dto.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from datetime import datetime, timedelta
+
+
+@dataclass
+class RunCompromisedDetails:
+    status: bool
+    comment: str | None = None
+    bug_id: str | None = None
+    bug_url: str | None = None
+
+
+@dataclass
+class RunRevision:
+    name: str
+    value: str
+    url: str
+
+
+@dataclass
+class RunSpecialCategory:
+    name: str
+    values: list[str]
+
+
+@dataclass
+class RunDetailsResult:
+    project_id: int
+    project_name: str
+    id: int
+    start: datetime | None
+    finish: datetime | None
+    duration: timedelta | None
+    main_package: str | None
+    status: str | None
+    status_by_nok: str
+    compromised: RunCompromisedDetails | None
+    conclusion: str
+    conclusion_reason: str | None
+    important_tags: list[str]
+    relevant_tags: list[str]
+    branches: list[str]
+    revisions: list[RunRevision]
+    labels: list[str]
+    special_categories: list[RunSpecialCategory]
+    configuration: str | None
+
+
+@dataclass
+class RunStatsValues:
+    passed: int
+    failed: int
+    passed_unexpected: int
+    failed_unexpected: int
+    skipped: int
+    skipped_unexpected: int
+    abnormal: int
+
+
+@dataclass
+class RunStatsComment:
+    comment_id: str
+    updated: str
+    serial: str
+    comment: str
+
+
+@dataclass
+class RunStatsResult:
+    result_id: int
+    exec_seqno: int
+    parent_id: int | None
+    type: str
+    test_id: int
+    test_name: str
+    period: str
+    path: list[str]
+    objective: str
+    children: list[RunStatsResult]
+    stats: RunStatsValues
+    comments: list[RunStatsComment]
+
+
+@dataclass
+class MarkRunCompromisedResult:
+    comment: str
+    bug: str | None
+
+
+@dataclass
+class RunSummaryStats:
+    tests_total: int
+    tests_total_plan_percent: int | None
+    tests_total_ok: int
+    tests_total_ok_percent: int
+    tests_total_nok: int
+    tests_total_nok_percent: int
+
+
+@dataclass
+class RunSummaryResult:
+    id: int
+    project_id: int
+    project_name: str
+    start: datetime | None
+    finish: datetime | None
+    duration: timedelta | None
+    status: str | None
+    status_by_nok: str
+    compromised: bool | None
+    conclusion: str
+    conclusion_reason: str | None
+    metadata: list[str]
+    important_tags: list[str]
+    relevant_tags: list[str]
+    stats: RunSummaryStats | None
+
+
+@dataclass
+class RunListPagination:
+    count: int
+    next: str | None
+    previous: str | None
+
+
+@dataclass
+class RunListResult:
+    pagination: RunListPagination
+    results: list[RunSummaryResult]
+
+
+@dataclass
+class RunCommentResult:
+    id: int
+    comment: str

--- a/bublik/core/run/services.py
+++ b/bublik/core/run/services.py
@@ -526,7 +526,7 @@ class RunService:
         )
 
     @staticmethod
-    def get_nok_distribution(run_id: int) -> dict:
+    def get_nok_distribution(run_id: int) -> list[bool]:
         """
         Get NOK (failure) distribution for a run.
 
@@ -534,10 +534,10 @@ class RunService:
             run_id: The ID of the test run
 
         Returns:
-            Dictionary with NOK distribution data
+            List of per-iteration NOK flags
         """
         run = RunService.get_run(run_id)
-        return get_nok_results_distribution(run)
+        return list(get_nok_results_distribution(run))
 
     @staticmethod
     def get_run_comment(run_id: int) -> str | None:

--- a/bublik/core/run/services.py
+++ b/bublik/core/run/services.py
@@ -280,8 +280,12 @@ class RunService:
             finish_date=finish_date,
             project_id=project_id,
         )
-        runs_details = generate_runs_details(runs)
-        return PaginatedResult.paginate_queryset(runs_details, page, page_size)
+        paginated_runs = PaginatedResult.paginate_queryset(runs, page, page_size)
+
+        return {
+            'pagination': paginated_runs['pagination'],
+            'results': generate_runs_details(paginated_runs['results']),
+        }
 
     @staticmethod
     def aggregate_runs_by_period(

--- a/bublik/core/run/services.py
+++ b/bublik/core/run/services.py
@@ -22,6 +22,14 @@ from bublik.core.run.compromised import (
     unmark_run_compromised,
     validate_compromised_request,
 )
+from bublik.core.run.dto import (
+    MarkRunCompromisedResult,
+    RunCommentResult,
+    RunDetailsResult,
+    RunListPagination,
+    RunListResult,
+    RunStatsResult,
+)
 from bublik.core.run.external_links import get_sources
 from bublik.core.run.filter_expression import filter_by_expression
 from bublik.core.run.stats import (
@@ -71,7 +79,7 @@ class RunService:
             raise NotFoundError(msg) from e
 
     @staticmethod
-    def get_run_details(run_id: int) -> dict:
+    def get_run_details(run_id: int) -> RunDetailsResult:
         """
         Get full details for a single run.
 
@@ -79,7 +87,7 @@ class RunService:
             run_id: The ID of the test run
 
         Returns:
-            Dictionary with full run details
+            RunDetailsResult with all details of the run.
         """
         run = RunService.get_run(run_id)
         return generate_all_run_details(run)
@@ -99,7 +107,10 @@ class RunService:
         return get_run_status(run)
 
     @staticmethod
-    def get_run_stats(run_id: int, requirements: str | None = None) -> dict:
+    def get_run_stats(
+        run_id: int,
+        requirements: str | None = None,
+    ) -> RunStatsResult | None:
         """
         Get statistics for a run.
 
@@ -108,7 +119,7 @@ class RunService:
             requirements: Optional requirements filter
 
         Returns:
-            Dictionary with run statistics
+            RunStatsResult with run statistics or None if stats are unavailable
         """
         return get_run_stats_detailed_with_comments(run_id, requirements)
 
@@ -149,7 +160,7 @@ class RunService:
         comment: str,
         bug_id: str | None = None,
         reference_key: str | None = None,
-    ) -> dict:
+    ) -> MarkRunCompromisedResult:
         """
         Mark a run as compromised.
 
@@ -160,7 +171,7 @@ class RunService:
             reference_key: Optional reference key
 
         Returns:
-            Dictionary with comment and bug info
+            MarkRunCompromisedResult with comment and bug info
 
         Raises:
             ValidationError: if validation fails
@@ -170,10 +181,10 @@ class RunService:
             raise ValidationError(err_msg)
 
         mark_run_compromised(run_id, comment, bug_id, reference_key)
-        return {
-            'comment': comment,
-            'bug': f'Bug ID: {bug_id}' if bug_id else None,
-        }
+        return MarkRunCompromisedResult(
+            comment=comment,
+            bug=f'Bug ID: {bug_id}' if bug_id else None,
+        )
 
     @staticmethod
     def unmark_run_compromised(run_id: int) -> None:
@@ -260,7 +271,7 @@ class RunService:
         project_id: int | None = None,
         page: int | None = None,
         page_size: int | None = None,
-    ) -> dict:
+    ) -> RunListResult:
         """
         List runs filtered by date range and optionally by project.
 
@@ -272,7 +283,7 @@ class RunService:
             page_size: Items per page (default: 25, max: 10000)
 
         Returns:
-            Dictionary with pagination metadata and run detail dictionaries
+            RunListResult with pagination metadata and run details
         """
 
         runs = RunService.list_runs_queryset(
@@ -282,10 +293,10 @@ class RunService:
         )
         paginated_runs = PaginatedResult.paginate_queryset(runs, page, page_size)
 
-        return {
-            'pagination': paginated_runs['pagination'],
-            'results': generate_runs_details(paginated_runs['results']),
-        }
+        return RunListResult(
+            pagination=RunListPagination(**paginated_runs['pagination']),
+            results=generate_runs_details(paginated_runs['results']),
+        )
 
     @staticmethod
     def aggregate_runs_by_period(
@@ -570,7 +581,7 @@ class RunService:
         return comments.first().meta.value
 
     @staticmethod
-    def create_run_comment(run_id: int, content: str) -> dict:
+    def create_run_comment(run_id: int, content: str) -> RunCommentResult:
         """
         Create or update run comment.
 
@@ -579,7 +590,7 @@ class RunService:
             content: Comment content
 
         Returns:
-            Dictionary with comment details
+            RunCommentResult with comment details
         """
         run = RunService.get_run(run_id)
 
@@ -598,10 +609,10 @@ class RunService:
             )
             mr, _ = mr_serializer.get_or_create()
 
-        return {
-            'id': mr.id,
-            'comment': mr.meta.value,
-        }
+        return RunCommentResult(
+            id=mr.id,
+            comment=mr.meta.value,
+        )
 
     @staticmethod
     def delete_run_comment(run_id: int) -> None:

--- a/bublik/core/run/stats.py
+++ b/bublik/core/run/stats.py
@@ -27,6 +27,17 @@ from bublik.core.run.data import (
     get_tags_by_runs,
     is_result_unexpected,
 )
+from bublik.core.run.dto import (
+    RunCompromisedDetails,
+    RunDetailsResult,
+    RunRevision,
+    RunSpecialCategory,
+    RunStatsComment,
+    RunStatsResult,
+    RunStatsValues,
+    RunSummaryResult,
+    RunSummaryStats,
+)
 from bublik.core.run.filter_expression import filter_by_expression
 from bublik.core.utils import key_value_dict_transforming, key_value_list_transforming
 from bublik.data.models import (
@@ -203,9 +214,29 @@ def generate_result(
 
 def get_run_stats_detailed_with_comments(run_id, requirements):
     run_stats = get_run_stats_detailed(run_id, requirements)
+    if run_stats is None:
+        return None
+
     tests_comments = get_tests_comments(run_id)
     add_comments(run_stats, tests_comments)
-    return run_stats
+    return _run_stats_data_to_result(run_stats)
+
+
+def _run_stats_data_to_result(stats_data):
+    return RunStatsResult(
+        result_id=stats_data['result_id'],
+        exec_seqno=stats_data['exec_seqno'],
+        parent_id=stats_data['parent_id'],
+        type=stats_data['type'],
+        test_id=stats_data['test_id'],
+        test_name=stats_data['test_name'],
+        period=stats_data['period'],
+        path=stats_data['path'],
+        objective=stats_data['objective'],
+        children=[_run_stats_data_to_result(child) for child in stats_data.get('children', [])],
+        stats=RunStatsValues(**stats_data['stats']),
+        comments=[RunStatsComment(**comment) for comment in stats_data.get('comments', [])],
+    )
 
 
 def add_comments(node, tests_comments):
@@ -440,14 +471,14 @@ def get_run_stats_summary(run_id):
         tests_total_ok_percent += 1
         tests_total_nok_percent -= 1
 
-    return {
-        'tests_total': tests_total,
-        'tests_total_plan_percent': tests_total_plan_percent,
-        'tests_total_ok': tests_total_ok,
-        'tests_total_ok_percent': tests_total_ok_percent,
-        'tests_total_nok': tests_total_nok,
-        'tests_total_nok_percent': tests_total_nok_percent,
-    }
+    return RunSummaryStats(
+        tests_total=tests_total,
+        tests_total_plan_percent=tests_total_plan_percent,
+        tests_total_ok=tests_total_ok,
+        tests_total_ok_percent=tests_total_ok_percent,
+        tests_total_nok=tests_total_nok,
+        tests_total_nok_percent=tests_total_nok_percent,
+    )
 
 
 def get_expected_results(result):
@@ -655,7 +686,10 @@ def generate_all_run_details(run):
     q = MetaResultsQuery(run_meta_results)
 
     branches = q.metas_query('branch')
-    revisions = build_revision_references(q.revision_related_query(), project.id)
+    revisions = [
+        RunRevision(**revision)
+        for revision in build_revision_references(q.revision_related_query(), project.id)
+    ]
     labels = q.labels_query(category_names, project.id)
     configurations = list(
         key_value_list_transforming(
@@ -664,32 +698,45 @@ def generate_all_run_details(run):
             ],
         ),
     )
-    categories = get_metas_by_category(run_meta_results, category_names, project.id)
-    for category, category_values in categories.items():
-        categories[category] = list(key_value_list_transforming(category_values))
+    categories = [
+        RunSpecialCategory(
+            name=category,
+            values=list(key_value_list_transforming(category_values)),
+        )
+        for category, category_values in get_metas_by_category(
+            run_meta_results,
+            category_names,
+            project.id,
+        ).items()
+    ]
+    compromised_details = get_compromised_details(run)
 
     logger.debug('[run_details]: preparing resulting dict')
-    return {
-        'project_id': project.id,
-        'project_name': project.name,
-        'id': run_id,
-        'start': run.start,
-        'finish': run.finish,
-        'duration': run.duration,
-        'main_package': run.main_package.iteration.test.name if run.main_package else None,
-        'status': get_run_status(run),
-        'status_by_nok': get_run_status_by_nok(run)[0],
-        'compromised': get_compromised_details(run),
-        'conclusion': conclusion,
-        'conclusion_reason': conclusion_reason,
-        'important_tags': important_tags.get(run_id, []),
-        'relevant_tags': relevant_tags.get(run_id, []),
-        'branches': list(key_value_list_transforming(branches)),
-        'revisions': revisions,
-        'labels': list(key_value_list_transforming(labels)),
-        'special_categories': categories,
-        'configuration': configurations[0] if configurations else None,
-    }
+    return RunDetailsResult(
+        project_id=project.id,
+        project_name=project.name,
+        id=run_id,
+        start=run.start,
+        finish=run.finish,
+        duration=run.duration,
+        main_package=run.main_package.iteration.test.name if run.main_package else None,
+        status=get_run_status(run),
+        status_by_nok=get_run_status_by_nok(run)[0],
+        compromised=(
+            RunCompromisedDetails(**compromised_details)
+            if compromised_details is not None
+            else None
+        ),
+        conclusion=conclusion,
+        conclusion_reason=conclusion_reason,
+        important_tags=important_tags.get(run_id, []),
+        relevant_tags=relevant_tags.get(run_id, []),
+        branches=list(key_value_list_transforming(branches)),
+        revisions=revisions,
+        labels=list(key_value_list_transforming(labels)),
+        special_categories=categories,
+        configuration=configurations[0] if configurations else None,
+    )
 
 
 def generate_runs_details(runs):
@@ -701,23 +748,23 @@ def generate_runs_details(runs):
         run_id = run.id
         conclusion, conclusion_reason = get_run_conclusion(run)
         runs_data.append(
-            {
-                'id': run_id,
-                'project_id': run.project.id,
-                'project_name': run.project.name,
-                'start': run.start,
-                'finish': run.finish,
-                'duration': run.duration,
-                'status': get_run_status(run),
-                'status_by_nok': get_run_status_by_nok(run)[0],
-                'compromised': is_run_compromised(run),
-                'conclusion': conclusion,
-                'conclusion_reason': conclusion_reason,
-                'metadata': metadata_by_runs.get(run_id, []),
-                'important_tags': important_tags.get(run_id, []),
-                'relevant_tags': relevant_tags.get(run_id, []),
-                'stats': get_run_stats_summary(run_id),
-            },
+            RunSummaryResult(
+                id=run_id,
+                project_id=run.project.id,
+                project_name=run.project.name,
+                start=run.start,
+                finish=run.finish,
+                duration=run.duration,
+                status=get_run_status(run),
+                status_by_nok=get_run_status_by_nok(run)[0],
+                compromised=is_run_compromised(run),
+                conclusion=conclusion,
+                conclusion_reason=conclusion_reason,
+                metadata=metadata_by_runs.get(run_id, []),
+                important_tags=important_tags.get(run_id, []),
+                relevant_tags=relevant_tags.get(run_id, []),
+                stats=get_run_stats_summary(run_id),
+            ),
         )
 
     return runs_data

--- a/bublik/interfaces/api_v2/__init__.py
+++ b/bublik/interfaces/api_v2/__init__.py
@@ -30,7 +30,8 @@ from .outside_domains import OutsideDomainsViewSet
 from .performance import PerformanceCheckView
 from .project import ProjectViewSet
 from .report import ReportViewSet
-from .results import ResultViewSet, RunViewSet
+from .result.views import ResultViewSet
+from .run.views import RunViewSet
 from .server import ServerViewSet
 from .tree import TreeViewSet
 from .url_shortener import URLShortenerView

--- a/bublik/interfaces/api_v2/result/views.py
+++ b/bublik/interfaces/api_v2/result/views.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
+
+from typing import ClassVar
+
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.viewsets import ModelViewSet
+
+from bublik.core.result import ResultService
+from bublik.core.run.stats import (
+    generate_results_details,
+)
+from bublik.data.serializers import (
+    TestIterationResultSerializer,
+)
+
+
+__all__ = [
+    'ResultViewSet',
+]
+
+
+class ResultViewSet(ModelViewSet):
+    serializer_class = TestIterationResultSerializer
+    filter_backends: ClassVar[list] = []
+
+    def get_queryset(self):
+        parent_id = self.request.query_params.get('parent_id')
+        test_name = self.request.query_params.get('test_name')
+        start_exec_seqno = self.request.query_params.get('start_exec_seqno')
+        results = self.request.query_params.get('results')
+        result_properties = self.request.query_params.get('result_properties')
+        requirements = self.request.query_params.get('requirements')
+
+        return ResultService.list_results(
+            parent_id=parent_id,
+            test_name=test_name,
+            start_exec_seqno=start_exec_seqno,
+            results=results,
+            result_properties=result_properties,
+            requirements=requirements,
+        )
+
+    def retrieve(self, request, pk=None):
+        return Response(data={'result': ResultService.get_result_details(pk)})
+
+    def list(self, request):
+        return Response(
+            data={'results': generate_results_details(self.get_queryset())},
+        )
+
+    @action(detail=True, methods=['get'])
+    def artifacts_and_verdicts(self, request, pk=None):
+        return Response(ResultService.get_result_artifacts_and_verdicts(pk))
+
+    @action(detail=True, methods=['get'])
+    def measurements(self, request, pk=None):
+        return Response(ResultService.get_result_measurements(pk))

--- a/bublik/interfaces/api_v2/results.py
+++ b/bublik/interfaces/api_v2/results.py
@@ -25,7 +25,7 @@ from bublik.data.serializers import (
 )
 
 
-all = [
+__all__ = [
     'RunViewSet',
     'ResultViewSet',
 ]

--- a/bublik/interfaces/api_v2/run/serializers.py
+++ b/bublik/interfaces/api_v2/run/serializers.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from bublik.core.run.dto import (
+        MarkRunCompromisedResult,
+        RunCommentResult,
+        RunCompromisedDetails,
+        RunDetailsResult,
+        RunRevision,
+        RunSpecialCategory,
+        RunStatsComment,
+        RunStatsResult,
+        RunStatsValues,
+        RunSummaryResult,
+        RunSummaryStats,
+    )
+
+
+def serialize_run_compromised_details(
+    compromised: RunCompromisedDetails | None,
+):
+    if compromised is None:
+        return None
+
+    return {
+        'status': compromised.status,
+        'comment': compromised.comment,
+        'bug_id': compromised.bug_id,
+        'bug_url': compromised.bug_url,
+    }
+
+
+def serialize_run_revision(revision: RunRevision):
+    return {
+        'name': revision.name,
+        'value': revision.value,
+        'url': revision.url,
+    }
+
+
+def serialize_run_special_categories(categories: list[RunSpecialCategory]):
+    return {category.name: category.values for category in categories}
+
+
+def serialize_run_details(run_details: RunDetailsResult):
+    return {
+        'project_id': run_details.project_id,
+        'project_name': run_details.project_name,
+        'id': run_details.id,
+        'start': run_details.start,
+        'finish': run_details.finish,
+        'duration': run_details.duration,
+        'main_package': run_details.main_package,
+        'status': run_details.status,
+        'status_by_nok': run_details.status_by_nok,
+        'compromised': serialize_run_compromised_details(run_details.compromised),
+        'conclusion': run_details.conclusion,
+        'conclusion_reason': run_details.conclusion_reason,
+        'important_tags': run_details.important_tags,
+        'relevant_tags': run_details.relevant_tags,
+        'branches': run_details.branches,
+        'revisions': [serialize_run_revision(revision) for revision in run_details.revisions],
+        'labels': run_details.labels,
+        'special_categories': serialize_run_special_categories(
+            run_details.special_categories,
+        ),
+        'configuration': run_details.configuration,
+    }
+
+
+def serialize_run_stats_values(stats: RunStatsValues):
+    return {
+        'passed': stats.passed,
+        'failed': stats.failed,
+        'passed_unexpected': stats.passed_unexpected,
+        'failed_unexpected': stats.failed_unexpected,
+        'skipped': stats.skipped,
+        'skipped_unexpected': stats.skipped_unexpected,
+        'abnormal': stats.abnormal,
+    }
+
+
+def serialize_run_stats_comment(comment: RunStatsComment):
+    return {
+        'comment_id': comment.comment_id,
+        'updated': comment.updated,
+        'serial': comment.serial,
+        'comment': comment.comment,
+    }
+
+
+def serialize_run_stats_result(stats: RunStatsResult | None):
+    if stats is None:
+        return None
+
+    return {
+        'result_id': stats.result_id,
+        'exec_seqno': stats.exec_seqno,
+        'parent_id': stats.parent_id,
+        'type': stats.type,
+        'test_id': stats.test_id,
+        'test_name': stats.test_name,
+        'period': stats.period,
+        'path': stats.path,
+        'objective': stats.objective,
+        'children': [serialize_run_stats_result(child) for child in stats.children],
+        'stats': serialize_run_stats_values(stats.stats),
+        'comments': [serialize_run_stats_comment(comment) for comment in stats.comments],
+    }
+
+
+def serialize_mark_run_compromised_result(result: MarkRunCompromisedResult):
+    return {
+        'comment': result.comment,
+        'bug': result.bug,
+    }
+
+
+def serialize_run_summary_stats(stats: RunSummaryStats | None):
+    if stats is None:
+        return None
+
+    return {
+        'tests_total': stats.tests_total,
+        'tests_total_plan_percent': stats.tests_total_plan_percent,
+        'tests_total_ok': stats.tests_total_ok,
+        'tests_total_ok_percent': stats.tests_total_ok_percent,
+        'tests_total_nok': stats.tests_total_nok,
+        'tests_total_nok_percent': stats.tests_total_nok_percent,
+    }
+
+
+def serialize_run_summary_result(result: RunSummaryResult):
+    return {
+        'id': result.id,
+        'project_id': result.project_id,
+        'project_name': result.project_name,
+        'start': result.start,
+        'finish': result.finish,
+        'duration': result.duration,
+        'status': result.status,
+        'status_by_nok': result.status_by_nok,
+        'compromised': result.compromised,
+        'conclusion': result.conclusion,
+        'conclusion_reason': result.conclusion_reason,
+        'metadata': result.metadata,
+        'important_tags': result.important_tags,
+        'relevant_tags': result.relevant_tags,
+        'stats': serialize_run_summary_stats(result.stats),
+    }
+
+
+def serialize_run_summary_results(results: list[RunSummaryResult]):
+    return [serialize_run_summary_result(result) for result in results]
+
+
+def serialize_paginated_run_summary_results(paginated_result):
+    paginated_result['results'] = serialize_run_summary_results(
+        paginated_result['results'],
+    )
+    return paginated_result
+
+
+def serialize_run_comment_result(result: RunCommentResult):
+    return {
+        'id': result.id,
+        'comment': result.comment,
+    }

--- a/bublik/interfaces/api_v2/run/views.py
+++ b/bublik/interfaces/api_v2/run/views.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
-from typing import ClassVar
-
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
@@ -11,10 +9,8 @@ from rest_framework.viewsets import ModelViewSet
 
 from bublik.core.cache import RunCache
 from bublik.core.config.services import ConfigServices
-from bublik.core.result import ResultService
 from bublik.core.run.services import RunsChartGroupBy, RunService
 from bublik.core.run.stats import (
-    generate_results_details,
     generate_runs_details,
 )
 from bublik.core.utils import get_difference
@@ -27,7 +23,6 @@ from bublik.data.serializers import (
 
 __all__ = [
     'RunViewSet',
-    'ResultViewSet',
 ]
 
 
@@ -165,41 +160,3 @@ class RunViewSet(ModelViewSet):
             return Response(status=status.HTTP_204_NO_CONTENT)
 
         return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
-
-
-class ResultViewSet(ModelViewSet):
-    serializer_class = TestIterationResultSerializer
-    filter_backends: ClassVar[list] = []
-
-    def get_queryset(self):
-        parent_id = self.request.query_params.get('parent_id')
-        test_name = self.request.query_params.get('test_name')
-        start_exec_seqno = self.request.query_params.get('start_exec_seqno')
-        results = self.request.query_params.get('results')
-        result_properties = self.request.query_params.get('result_properties')
-        requirements = self.request.query_params.get('requirements')
-
-        return ResultService.list_results(
-            parent_id=parent_id,
-            test_name=test_name,
-            start_exec_seqno=start_exec_seqno,
-            results=results,
-            result_properties=result_properties,
-            requirements=requirements,
-        )
-
-    def retrieve(self, request, pk=None):
-        return Response(data={'result': ResultService.get_result_details(pk)})
-
-    def list(self, request):
-        return Response(
-            data={'results': generate_results_details(self.get_queryset())},
-        )
-
-    @action(detail=True, methods=['get'])
-    def artifacts_and_verdicts(self, request, pk=None):
-        return Response(ResultService.get_result_artifacts_and_verdicts(pk))
-
-    @action(detail=True, methods=['get'])
-    def measurements(self, request, pk=None):
-        return Response(ResultService.get_result_measurements(pk))

--- a/bublik/interfaces/api_v2/run/views.py
+++ b/bublik/interfaces/api_v2/run/views.py
@@ -19,6 +19,13 @@ from bublik.data.serializers import (
     RunCommentSerializer,
     TestIterationResultSerializer,
 )
+from bublik.interfaces.api_v2.run.serializers import (
+    serialize_mark_run_compromised_result,
+    serialize_run_comment_result,
+    serialize_run_details,
+    serialize_run_stats_result,
+    serialize_run_summary_results,
+)
 
 
 __all__ = [
@@ -51,7 +58,7 @@ class RunViewSet(ModelViewSet):
         return Response(
             {
                 'pagination': self.paginator.get_pagination(),
-                'results': generate_runs_details(results),
+                'results': serialize_run_summary_results(generate_runs_details(results)),
             },
         )
 
@@ -90,15 +97,16 @@ class RunViewSet(ModelViewSet):
 
     @action(detail=True, methods=['get'])
     def details(self, _request, pk=None):
-        return Response(data=RunService.get_run_details(pk))
+        return Response(data=serialize_run_details(RunService.get_run_details(pk)))
 
     @action(detail=True, methods=['get'])
     def stats(self, _request, pk=None):
         requirements = self.request.query_params.get('requirements')
         project_id = TestIterationResult.objects.get(id=pk).project.id
+        run_stats = RunService.get_run_stats(pk, requirements)
         return Response(
             {
-                'results': RunService.get_run_stats(pk, requirements),
+                'results': serialize_run_stats_result(run_stats),
                 'default_columns': ConfigServices.getattr_from_global(
                     GlobalConfigs.PER_CONF.name,
                     'RUN_STATS_COLUMNS_DEFAULT',
@@ -127,7 +135,11 @@ class RunViewSet(ModelViewSet):
             comment = request.data.get('comment')
             bug_id = request.data.get('bug_id')
             reference_key = request.data.get('reference_key')
-            return Response(RunService.mark_run_compromised(pk, comment, bug_id, reference_key))
+            return Response(
+                serialize_mark_run_compromised_result(
+                    RunService.mark_run_compromised(pk, comment, bug_id, reference_key),
+                ),
+            )
         try:
             RunService.unmark_run_compromised(pk)
             return Response({'message': f'Run {pk} is no longer compromised'})
@@ -148,12 +160,15 @@ class RunViewSet(ModelViewSet):
         if request.method == 'POST':
             content = request.data.get('comment')
             result = RunService.create_run_comment(pk, content)
-            return Response(result, status=status.HTTP_201_CREATED)
+            return Response(
+                serialize_run_comment_result(result),
+                status=status.HTTP_201_CREATED,
+            )
 
         if request.method == 'PUT':
             content = request.data.get('comment')
             result = RunService.create_run_comment(pk, content)
-            return Response(result, status=status.HTTP_200_OK)
+            return Response(serialize_run_comment_result(result), status=status.HTTP_200_OK)
 
         if request.method == 'DELETE':
             RunService.delete_run_comment(pk)

--- a/bublik/mcp/tools.py
+++ b/bublik/mcp/tools.py
@@ -19,6 +19,11 @@ from bublik.core.run.services import RunService
 from bublik.core.run.stats import generate_runs_details, get_test_runs
 from bublik.core.server import ServerService
 from bublik.core.tree.services import TreeService
+from bublik.interfaces.api_v2.run.serializers import (
+    serialize_paginated_run_summary_results,
+    serialize_run_details,
+    serialize_run_stats_result,
+)
 from bublik.mcp.models import JsonLog
 from bublik.mcp.processor import LogProcessor
 
@@ -59,7 +64,7 @@ def register_tools(mcp: FastMCP):  # noqa: C901
         Returns:
             Dictionary with full run details including metadata, stats, etc.
         """
-        return await sync_to_async(RunService.get_run_details)(run_id)
+        return serialize_run_details(await sync_to_async(RunService.get_run_details)(run_id))
 
     @mcp.tool()
     async def get_run_status(run_id: int) -> str:
@@ -89,7 +94,9 @@ def register_tools(mcp: FastMCP):  # noqa: C901
         Returns:
             Dictionary with run statistics including pass/fail counts
         """
-        return await sync_to_async(RunService.get_run_stats)(run_id, requirements)
+        return serialize_run_stats_result(
+            await sync_to_async(RunService.get_run_stats)(run_id, requirements),
+        )
 
     @mcp.tool()
     async def get_run_source(run_id: int) -> str:
@@ -257,10 +264,12 @@ def register_tools(mcp: FastMCP):  # noqa: C901
             branch_expr=branch_expr,
         )
         runs_details = await sync_to_async(generate_runs_details)(queryset)
-        return await sync_to_async(PaginatedResult.paginate_queryset)(
-            runs_details,
-            page,
-            page_size,
+        return serialize_paginated_run_summary_results(
+            await sync_to_async(PaginatedResult.paginate_queryset)(
+                runs_details,
+                page,
+                page_size,
+            ),
         )
 
     @mcp.tool()
@@ -292,10 +301,12 @@ def register_tools(mcp: FastMCP):  # noqa: C901
             else []
         )
         runs_details = await sync_to_async(generate_runs_details)(queryset) if date_str else []
-        return await sync_to_async(PaginatedResult.paginate_queryset)(
-            runs_details,
-            page,
-            page_size,
+        return serialize_paginated_run_summary_results(
+            await sync_to_async(PaginatedResult.paginate_queryset)(
+                runs_details,
+                page,
+                page_size,
+            ),
         )
 
     @mcp.tool()


### PR DESCRIPTION
## Description

### Summary

Prepare API v2 run and result modules for independent evolution, fix
response materialization for NOK distribution, improve run list pagination
performance, and introduce DTO-based run service contracts.

### Changes

- Fix result API module exports.
- Move run API code into dedicated module structure.
- Materialize NOK distribution responses as `list[bool]`.
- Paginate runs before building detailed run data.
- Introduce DTO-backed contracts for run details, stats, list, comments,
  and compromised marking responses.

### Notes

The run list response shape stays unchanged, but detailed run data is now
generated only for the requested page.