### PR TITLE
run: make results contracts accurate in Swagger

### DIFF
--- a/bublik/interfaces/api_v2/__init__.py
+++ b/bublik/interfaces/api_v2/__init__.py
@@ -30,7 +30,7 @@ from .outside_domains import OutsideDomainsViewSet
 from .performance import PerformanceCheckView
 from .project import ProjectViewSet
 from .report import ReportViewSet
-from .results import ResultViewSet, RunViewSet
+from .results.views import ResultViewSet, RunViewSet
 from .server import ServerViewSet
 from .tree import TreeViewSet
 from .url_shortener import URLShortenerView

--- a/bublik/interfaces/api_v2/results/schemas.py
+++ b/bublik/interfaces/api_v2/results/schemas.py
@@ -1,0 +1,394 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+
+from bublik.interfaces.api_v2.errors.serializers import ErrorResponseSerializer
+from bublik.interfaces.api_v2.results.serializers import (
+    DropCacheRequestSerializer,
+    DropCacheResponseSerializer,
+    MarkRunCompromisedRequestSerializer,
+    MarkRunCompromisedResponseSerializer,
+    ResultArtifactsAndVerdictsResponseSerializer,
+    ResultListQuerySerializer,
+    ResultListResponseSerializer,
+    ResultMeasurementsResponseSerializer,
+    ResultRetrieveResponseSerializer,
+    RunCommentRequestSerializer,
+    RunCommentResponseSerializer,
+    RunCommentValueResponseSerializer,
+    RunCompromisedResponseSerializer,
+    RunDetailsResponseSerializer,
+    RunListQuerySerializer,
+    RunListResponseSerializer,
+    RunRequirementsResponseSerializer,
+    RunSourceResponseSerializer,
+    RunStatsQuerySerializer,
+    RunStatsResponseSerializer,
+    RunStatusResponseSerializer,
+    UnmarkRunCompromisedResponseSerializer,
+)
+
+
+RUN_TAG = 'Runs'
+RESULT_TAG = 'Results'
+
+
+run_viewset_schema = extend_schema_view(
+    list=extend_schema(
+        summary='List runs',
+        description='''
+        Returns a paginated list of test runs with project, timing, status,
+        classification, metadata, tag, and summary statistics fields.
+        Supports date, project, status, metadata, and expression filters.
+        ''',
+        parameters=[RunListQuerySerializer],
+        responses={
+            200: OpenApiResponse(
+                response=RunListResponseSerializer,
+                description='Runs were successfully retrieved',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    drop_cache=extend_schema(
+        summary='Drop run cache',
+        description='''
+        Deletes selected cache entries for every run matching the current run
+        filters and returns identifiers of affected runs.
+        ''',
+        request=DropCacheRequestSerializer,
+        responses={
+            200: OpenApiResponse(
+                response=DropCacheResponseSerializer,
+                description='Run cache entries were successfully deleted',
+            ),
+            400: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Unknown cache key was provided',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    nok_distribution=extend_schema(
+        summary='Get NOK distribution',
+        description='''
+        Returns a boolean NOK flag for each test result in the run.
+        ''',
+        responses={
+            200: OpenApiResponse(
+                response={'type': 'array', 'items': {'type': 'boolean'}},
+                description='NOK distribution was successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    details=extend_schema(
+        summary='Get run details',
+        description='''
+        Returns full details for a single run, including metadata, tags,
+        branches, revisions, labels, configuration, status, and conclusion.
+        ''',
+        responses={
+            200: OpenApiResponse(
+                response=RunDetailsResponseSerializer,
+                description='Run details were successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    stats=extend_schema(
+        summary='Get run statistics',
+        description='''
+        Returns the run result tree with aggregated pass/fail statistics and
+        comments. The optional requirements filter limits statistics to tests
+        matching the provided requirement list.
+        ''',
+        parameters=[RunStatsQuerySerializer],
+        responses={
+            200: OpenApiResponse(
+                response=RunStatsResponseSerializer,
+                description='Run statistics were successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    requirements=extend_schema(
+        summary='List run requirements',
+        description='''
+        Returns sorted requirement values associated with a run.
+        ''',
+        responses={
+            200: OpenApiResponse(
+                response=RunRequirementsResponseSerializer,
+                description='Run requirements were successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    source=extend_schema(
+        summary='Get run source URL',
+        description='''
+        Returns the external source URL associated with a run.
+        ''',
+        responses={
+            200: OpenApiResponse(
+                response=RunSourceResponseSerializer,
+                description='Run source URL was successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    status=extend_schema(
+        summary='Get run status',
+        description='''
+        Returns the configured status value for a run.
+        ''',
+        responses={
+            200: OpenApiResponse(
+                response=RunStatusResponseSerializer,
+                description='Run status was successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    compromised=extend_schema(
+        summary='Get run compromised status',
+        description='''
+        Returns whether a run is marked as compromised.
+        ''',
+        responses={
+            200: OpenApiResponse(
+                response=RunCompromisedResponseSerializer,
+                description='Run compromised status was successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    comment=extend_schema(
+        summary='Get run comment',
+        description='''
+        Returns the current run comment, or null if no comment exists.
+        ''',
+        responses={
+            200: OpenApiResponse(
+                response=RunCommentValueResponseSerializer,
+                description='Run comment was successfully retrieved',
+            ),
+            400: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Multiple comments were found for the run',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+)
+
+
+mark_compromised_schema = extend_schema(
+    summary='Mark run as compromised',
+    description='''
+    Marks a run as compromised using a required comment and optional bug
+    reference data.
+    ''',
+    request=MarkRunCompromisedRequestSerializer,
+    responses={
+        200: OpenApiResponse(
+            response=MarkRunCompromisedResponseSerializer,
+            description='Run was successfully marked as compromised',
+        ),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description='Compromised request validation failed',
+        ),
+        404: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description='Run was not found',
+        ),
+    },
+    tags=[RUN_TAG],
+)
+
+
+unmark_compromised_schema = extend_schema(
+    summary='Unmark run as compromised',
+    description='''
+    Removes the compromised marker from a run.
+    ''',
+    responses={
+        200: OpenApiResponse(
+            response=UnmarkRunCompromisedResponseSerializer,
+            description='Run was successfully unmarked as compromised',
+        ),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description='Run could not be unmarked',
+        ),
+    },
+    tags=[RUN_TAG],
+)
+
+
+create_comment_schema = extend_schema(
+    summary='Create run comment',
+    description='''
+    Creates or replaces a run comment.
+    ''',
+    request=RunCommentRequestSerializer,
+    responses={
+        201: OpenApiResponse(
+            response=RunCommentResponseSerializer,
+            description='Run comment was successfully created',
+        ),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description='Run comment request validation failed',
+        ),
+    },
+    tags=[RUN_TAG],
+)
+
+
+update_comment_schema = extend_schema(
+    summary='Update run comment',
+    description='''
+    Creates or replaces a run comment.
+    ''',
+    request=RunCommentRequestSerializer,
+    responses={
+        200: OpenApiResponse(
+            response=RunCommentResponseSerializer,
+            description='Run comment was successfully updated',
+        ),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description='Run comment request validation failed',
+        ),
+    },
+    tags=[RUN_TAG],
+)
+
+
+delete_comment_schema = extend_schema(
+    summary='Delete run comment',
+    description='''
+    Deletes the current run comment.
+    ''',
+    responses={
+        204: OpenApiResponse(description='Run comment was successfully deleted'),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description='No comment exists for the run',
+        ),
+    },
+    tags=[RUN_TAG],
+)
+
+
+result_viewset_schema = extend_schema_view(
+    retrieve=extend_schema(
+        summary='Get result details',
+        description='''
+        Returns full details for a single test iteration result, including
+        expected and obtained results, artifacts, parameters, comments,
+        requirements, error state, and measurement availability.
+        ''',
+        responses={
+            200: OpenApiResponse(
+                response=ResultRetrieveResponseSerializer,
+                description='Result details were successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Result was not found',
+            ),
+        },
+        tags=[RESULT_TAG],
+    ),
+    list=extend_schema(
+        summary='List results',
+        description='''
+        Returns test iteration results matching the provided parent, test name,
+        execution sequence, result status, classification, and requirement
+        filters.
+        ''',
+        parameters=[ResultListQuerySerializer],
+        responses={
+            200: OpenApiResponse(
+                response=ResultListResponseSerializer,
+                description='Results were successfully retrieved',
+            ),
+            400: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Result filter validation failed',
+            ),
+        },
+        tags=[RESULT_TAG],
+    ),
+    artifacts_and_verdicts=extend_schema(
+        summary='Get result artifacts and verdicts',
+        description='''
+        Returns artifact and verdict meta values for a result.
+        ''',
+        responses={
+            200: OpenApiResponse(
+                response=ResultArtifactsAndVerdictsResponseSerializer,
+                description='Artifacts and verdicts were successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Result was not found',
+            ),
+        },
+        tags=[RESULT_TAG],
+    ),
+    measurements=extend_schema(
+        summary='Get result measurements',
+        description='''
+        Returns measurement chart and table data for a result.
+        ''',
+        responses={
+            200: OpenApiResponse(
+                response=ResultMeasurementsResponseSerializer,
+                description='Result measurements were successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Result was not found',
+            ),
+        },
+        tags=[RESULT_TAG],
+    ),
+)

--- a/bublik/interfaces/api_v2/results/serializers.py
+++ b/bublik/interfaces/api_v2/results/serializers.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+from rest_framework import serializers
+
+
+class PaginationSerializer(serializers.Serializer):
+    count = serializers.IntegerField()
+    next = serializers.CharField(allow_null=True)
+    previous = serializers.CharField(allow_null=True)
+
+
+class RunListQuerySerializer(serializers.Serializer):
+    start_date = serializers.DateField(required=False)
+    finish_date = serializers.DateField(required=False)
+    project = serializers.IntegerField(required=False)
+    run_status = serializers.CharField(required=False)
+    run_metas = serializers.CharField(required=False)
+    tag_expr = serializers.CharField(required=False)
+    label_expr = serializers.CharField(required=False)
+    revision_expr = serializers.CharField(required=False)
+    branch_expr = serializers.CharField(required=False)
+
+
+class DropCacheRequestSerializer(serializers.Serializer):
+    keys = serializers.ListField(child=serializers.CharField())
+
+
+class DropCacheResponseSerializer(serializers.Serializer):
+    results = serializers.ListField(child=serializers.IntegerField())
+
+
+class CompromisedDetailsSerializer(serializers.Serializer):
+    status = serializers.BooleanField()
+    comment = serializers.CharField(allow_null=True, required=False)
+    bug_id = serializers.CharField(allow_null=True, required=False)
+    bug_url = serializers.CharField(allow_null=True, required=False)
+
+
+class RevisionSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    value = serializers.CharField()
+    url = serializers.CharField(allow_blank=True)
+
+
+class RunSummaryStatsSerializer(serializers.Serializer):
+    tests_total = serializers.IntegerField()
+    tests_total_plan_percent = serializers.IntegerField(allow_null=True)
+    tests_total_ok = serializers.IntegerField()
+    tests_total_ok_percent = serializers.IntegerField()
+    tests_total_nok = serializers.IntegerField()
+    tests_total_nok_percent = serializers.IntegerField()
+
+
+class RunListItemSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    project_id = serializers.IntegerField()
+    project_name = serializers.CharField()
+    start = serializers.DateTimeField(allow_null=True)
+    finish = serializers.DateTimeField(allow_null=True)
+    duration = serializers.DurationField(allow_null=True)
+    status = serializers.CharField(allow_null=True)
+    status_by_nok = serializers.CharField()
+    compromised = serializers.BooleanField(allow_null=True)
+    conclusion = serializers.CharField()
+    conclusion_reason = serializers.CharField(allow_null=True)
+    metadata = serializers.ListField(child=serializers.CharField())
+    important_tags = serializers.ListField(child=serializers.CharField())
+    relevant_tags = serializers.ListField(child=serializers.CharField())
+    stats = RunSummaryStatsSerializer(allow_null=True)
+
+
+class RunListResponseSerializer(serializers.Serializer):
+    pagination = PaginationSerializer()
+    results = RunListItemSerializer(many=True)
+
+
+class RunDetailsResponseSerializer(serializers.Serializer):
+    project_id = serializers.IntegerField()
+    project_name = serializers.CharField()
+    id = serializers.IntegerField()
+    start = serializers.DateTimeField(allow_null=True)
+    finish = serializers.DateTimeField(allow_null=True)
+    duration = serializers.DurationField(allow_null=True)
+    main_package = serializers.CharField(allow_null=True)
+    status = serializers.CharField(allow_null=True)
+    status_by_nok = serializers.CharField()
+    compromised = CompromisedDetailsSerializer(allow_null=True)
+    conclusion = serializers.CharField()
+    conclusion_reason = serializers.CharField(allow_null=True)
+    important_tags = serializers.ListField(child=serializers.CharField())
+    relevant_tags = serializers.ListField(child=serializers.CharField())
+    branches = serializers.ListField(child=serializers.CharField())
+    revisions = RevisionSerializer(many=True)
+    labels = serializers.ListField(child=serializers.CharField())
+    special_categories = serializers.DictField(
+        child=serializers.ListField(child=serializers.CharField()),
+    )
+    configuration = serializers.CharField(allow_null=True)
+
+
+class RunStatsQuerySerializer(serializers.Serializer):
+    requirements = serializers.CharField(required=False)
+
+
+class RunStatsValuesSerializer(serializers.Serializer):
+    passed = serializers.IntegerField()
+    failed = serializers.IntegerField()
+    passed_unexpected = serializers.IntegerField()
+    failed_unexpected = serializers.IntegerField()
+    skipped = serializers.IntegerField()
+    skipped_unexpected = serializers.IntegerField()
+    abnormal = serializers.IntegerField()
+
+
+class RunStatsCommentSerializer(serializers.Serializer):
+    comment_id = serializers.CharField()
+    updated = serializers.CharField()
+    serial = serializers.CharField()
+    comment = serializers.CharField()
+
+
+class RunStatsNodeSerializer(serializers.Serializer):
+    result_id = serializers.IntegerField()
+    exec_seqno = serializers.IntegerField()
+    parent_id = serializers.IntegerField(allow_null=True)
+    type = serializers.CharField()
+    test_id = serializers.IntegerField()
+    test_name = serializers.CharField()
+    period = serializers.CharField()
+    path = serializers.ListField(child=serializers.CharField())
+    objective = serializers.CharField(allow_blank=True)
+    children = serializers.ListField(
+        child=serializers.DictField(),
+        help_text='Child nodes with the same structure.',
+    )
+    stats = RunStatsValuesSerializer()
+    comments = RunStatsCommentSerializer(many=True)
+
+
+class RunStatsResponseSerializer(serializers.Serializer):
+    results = RunStatsNodeSerializer(allow_null=True)
+
+
+class RunRequirementsResponseSerializer(serializers.Serializer):
+    requirements = serializers.ListField(child=serializers.CharField())
+
+
+class RunSourceResponseSerializer(serializers.Serializer):
+    url = serializers.CharField(allow_null=True)
+
+
+class RunStatusResponseSerializer(serializers.Serializer):
+    status = serializers.CharField(allow_null=True)
+
+
+class RunCompromisedResponseSerializer(serializers.Serializer):
+    compromised = serializers.BooleanField()
+
+
+class MarkRunCompromisedRequestSerializer(serializers.Serializer):
+    comment = serializers.CharField()
+    bug_id = serializers.CharField(required=False, allow_null=True)
+    reference_key = serializers.CharField(required=False, allow_null=True)
+
+
+class MarkRunCompromisedResponseSerializer(serializers.Serializer):
+    comment = serializers.CharField()
+    bug = serializers.CharField(allow_null=True)
+
+
+class UnmarkRunCompromisedResponseSerializer(serializers.Serializer):
+    message = serializers.CharField()
+
+
+class RunCommentRequestSerializer(serializers.Serializer):
+    comment = serializers.CharField()
+
+
+class RunCommentValueResponseSerializer(serializers.Serializer):
+    comment = serializers.CharField(allow_null=True)
+
+
+class RunCommentResponseSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    comment = serializers.CharField()
+
+
+class ResultListQuerySerializer(serializers.Serializer):
+    parent_id = serializers.IntegerField(required=False)
+    test_name = serializers.CharField(required=False)
+    start_exec_seqno = serializers.IntegerField(required=False)
+    results = serializers.CharField(required=False)
+    result_properties = serializers.CharField(required=False)
+    requirements = serializers.CharField(required=False)
+
+
+class ResultKeySerializer(serializers.Serializer):
+    name = serializers.CharField()
+    url = serializers.CharField(allow_null=True)
+
+
+class ExpectedResultSerializer(serializers.Serializer):
+    result_type = serializers.CharField(allow_null=True)
+    verdicts = serializers.ListField(child=serializers.CharField())
+    keys = ResultKeySerializer(many=True)
+
+
+class ObtainedResultSerializer(serializers.Serializer):
+    result_type = serializers.CharField(allow_null=True)
+    verdicts = serializers.ListField(child=serializers.CharField())
+
+
+class ResultDetailsSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    result_id = serializers.IntegerField()
+    run_id = serializers.IntegerField()
+    project_id = serializers.IntegerField()
+    project_name = serializers.CharField()
+    iteration_id = serializers.IntegerField()
+    start = serializers.DateTimeField(allow_null=True)
+    obtained_result = ObtainedResultSerializer()
+    expected_results = ExpectedResultSerializer(many=True)
+    artifacts = serializers.ListField(child=serializers.CharField())
+    parameters = serializers.ListField(child=serializers.CharField())
+    comments = serializers.ListField(child=serializers.CharField())
+    requirements = serializers.ListField(child=serializers.CharField())
+    has_error = serializers.BooleanField()
+    has_measurements = serializers.BooleanField()
+
+
+class ResultListResponseSerializer(serializers.Serializer):
+    results = ResultDetailsSerializer(many=True)
+
+
+class ResultRetrieveResponseSerializer(serializers.Serializer):
+    result = ResultDetailsSerializer()
+
+
+class MetaValueSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField(allow_null=True)
+    type = serializers.CharField()
+    value = serializers.CharField(allow_null=True)
+    hash = serializers.CharField()
+    comment = serializers.CharField(allow_null=True)
+
+
+class ResultArtifactsAndVerdictsResponseSerializer(serializers.Serializer):
+    artifacts = MetaValueSerializer(many=True)
+    verdicts = MetaValueSerializer(many=True)
+
+
+class ResultMeasurementsResponseSerializer(serializers.Serializer):
+    run_id = serializers.IntegerField(allow_null=True)
+    iteration_id = serializers.IntegerField()
+    charts = serializers.ListField(child=serializers.DictField())
+    tables = serializers.ListField(child=serializers.DictField())

--- a/bublik/interfaces/api_v2/results/views.py
+++ b/bublik/interfaces/api_v2/results/views.py
@@ -17,18 +17,26 @@ from bublik.core.run.stats import (
     generate_runs_details,
 )
 from bublik.core.utils import get_difference
-from bublik.data.serializers import (
-    RunCommentSerializer,
-    TestIterationResultSerializer,
+from bublik.data.serializers import TestIterationResultSerializer
+from bublik.interfaces.api_v2.results.schemas import (
+    create_comment_schema,
+    delete_comment_schema,
+    mark_compromised_schema,
+    result_viewset_schema,
+    run_viewset_schema,
+    unmark_compromised_schema,
+    update_comment_schema,
 )
+from bublik.interfaces.api_v2.results.serializers import RunCommentRequestSerializer
 
 
-all = [
-    'RunViewSet',
+__all__ = [
     'ResultViewSet',
+    'RunViewSet',
 ]
 
 
+@run_viewset_schema
 class RunViewSet(ModelViewSet):
     serializer_class = TestIterationResultSerializer
 
@@ -98,15 +106,21 @@ class RunViewSet(ModelViewSet):
     def status(self, _request, pk=None):
         return Response({'status': RunService.get_run_status(pk)})
 
-    @action(detail=True, methods=['get', 'post', 'delete'])
-    def compromised(self, request, pk=None):
-        if request.method == 'GET':
-            return Response(RunService.get_run_compromised(pk))
-        if request.method == 'POST':
-            comment = request.data.get('comment')
-            bug_id = request.data.get('bug_id')
-            reference_key = request.data.get('reference_key')
-            return Response(RunService.mark_run_compromised(pk, comment, bug_id, reference_key))
+    @action(detail=True, methods=['get'])
+    def compromised(self, _request, pk=None):
+        return Response(RunService.get_run_compromised(pk))
+
+    @mark_compromised_schema
+    @compromised.mapping.post
+    def mark_compromised(self, request, pk=None):
+        comment = request.data.get('comment')
+        bug_id = request.data.get('bug_id')
+        reference_key = request.data.get('reference_key')
+        return Response(RunService.mark_run_compromised(pk, comment, bug_id, reference_key))
+
+    @unmark_compromised_schema
+    @compromised.mapping.delete
+    def unmark_compromised(self, _request, pk=None):
         try:
             RunService.unmark_run_compromised(pk)
             return Response({'message': f'Run {pk} is no longer compromised'})
@@ -116,31 +130,35 @@ class RunViewSet(ModelViewSet):
 
     @action(
         detail=True,
-        methods=['get', 'post', 'put', 'delete'],
-        serializer_class=RunCommentSerializer,
+        methods=['get'],
+        serializer_class=RunCommentRequestSerializer,
     )
-    def comment(self, request, pk=None):
-        if request.method == 'GET':
-            comment = RunService.get_run_comment(pk)
-            return Response({'comment': comment})
+    def comment(self, _request, pk=None):
+        comment = RunService.get_run_comment(pk)
+        return Response({'comment': comment})
 
-        if request.method == 'POST':
-            content = request.data.get('comment')
-            result = RunService.create_run_comment(pk, content)
-            return Response(result, status=status.HTTP_201_CREATED)
+    @create_comment_schema
+    @comment.mapping.post
+    def create_comment(self, request, pk=None):
+        content = request.data.get('comment')
+        result = RunService.create_run_comment(pk, content)
+        return Response(result, status=status.HTTP_201_CREATED)
 
-        if request.method == 'PUT':
-            content = request.data.get('comment')
-            result = RunService.create_run_comment(pk, content)
-            return Response(result, status=status.HTTP_200_OK)
+    @update_comment_schema
+    @comment.mapping.put
+    def update_comment(self, request, pk=None):
+        content = request.data.get('comment')
+        result = RunService.create_run_comment(pk, content)
+        return Response(result, status=status.HTTP_200_OK)
 
-        if request.method == 'DELETE':
-            RunService.delete_run_comment(pk)
-            return Response(status=status.HTTP_204_NO_CONTENT)
+    @delete_comment_schema
+    @comment.mapping.delete
+    def delete_comment(self, _request, pk=None):
+        RunService.delete_run_comment(pk)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
-        return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-
+@result_viewset_schema
 class ResultViewSet(ModelViewSet):
     serializer_class = TestIterationResultSerializer
     filter_backends: ClassVar[list] = []


### PR DESCRIPTION
The results API was moved into a package layout, but it still used a
single views.py without local serializers or schema decorators. As a
result, generated DRF/OpenAPI documentation could not describe the
runs and results endpoints with the same precision as newer api_v2
modules.

This change documents the results API explicitly so Swagger reflects
the actual request and response contracts for run and result actions.

Changes

- Add results serializers for run lists, run details, run stats,
  compromised state, comments, result details, artifacts, verdicts,
  and measurements.
- Add results schema decorators using the same style as documented
  api_v2 modules.
- Apply schema decorators to RunViewSet and ResultViewSet.
- Split multi-method comment and compromised actions into DRF mapping
  methods so each HTTP method has its own schema.
- Keep runtime response behavior unchanged while making Swagger show
  the correct payload shape for each method.