### PR TITLE
Run/config: allow configuring default columns for run stats table

### DIFF
--- a/bublik/data/schemas/per_conf.json
+++ b/bublik/data/schemas/per_conf.json
@@ -156,6 +156,91 @@
             "uniqueItems": true,
             "default": ["Configuration"]
         },
+        "RUN_STATS_COLUMNS_DEFAULT": {
+            "description": "Column names to display by default in the run stats table, in display order",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "oneOf": [
+                    {
+                        "const": "objective",
+                        "title": "Objective",
+                        "description": "Test objective"
+                    },
+                    {
+                        "const": "comments",
+                        "title": "Notes",
+                        "description": "User-provided comment for the test"
+                    },
+                    {
+                        "const": "total",
+                        "title": "Total",
+                        "description": "Total number of iterations"
+                    },
+                    {
+                        "const": "run",
+                        "title": "Run",
+                        "description": "Number of iterations actually run (all except skipped)"
+                    },
+                    {
+                        "const": "total_expected",
+                        "title": "Expected Total",
+                        "description": "Total number of expected iterations"
+                    },
+                    {
+                        "const": "passed",
+                        "title": "Expected Passed",
+                        "description": "Number of iterations that passed as expected"
+                    },
+                    {
+                        "const": "failed",
+                        "title": "Expected Failed",
+                        "description": "Number of iterations that failed as expected"
+                    },
+                    {
+                        "const": "total_unexpected",
+                        "title": "Unexpected Total",
+                        "description": "Total number of unexpected iterations"
+                    },
+                    {
+                        "const": "passed_unexpected",
+                        "title": "Unexpected Passed",
+                        "description": "Number of iterations that passed unexpectedly"
+                    },
+                    {
+                        "const": "failed_unexpected",
+                        "title": "Unexpected Failed",
+                        "description": "Number of iterations that failed unexpectedly"
+                    },
+                    {
+                        "const": "skipped",
+                        "title": "Expected Skipped",
+                        "description": "Number of iterations that were skipped as expected"
+                    },
+                    {
+                        "const": "skipped_unexpected",
+                        "title": "Unexpected Skipped",
+                        "description": "Number of iterations that were skipped unexpectedly"
+                    },
+                    {
+                        "const": "abnormal",
+                        "title": "Abnormal",
+                        "description": "Number of iterations that terminated abnormally"
+                    }
+                ]
+            },
+            "uniqueItems": true,
+            "default": [
+                "run",
+                "passed",
+                "failed",
+                "passed_unexpected",
+                "failed_unexpected",
+                "skipped",
+                "skipped_unexpected",
+                "abnormal"
+            ]
+        },
         "RUN_STATUS_META": {
             "description": "Represents meta name in meta_data.json that defines run status",
             "type": "string",

--- a/bublik/interfaces/api_v2/results.py
+++ b/bublik/interfaces/api_v2/results.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
 from bublik.core.cache import RunCache
+from bublik.core.config.services import ConfigServices
 from bublik.core.result import ResultService
 from bublik.core.run.services import RunsChartGroupBy, RunService
 from bublik.core.run.stats import (
@@ -17,6 +18,7 @@ from bublik.core.run.stats import (
     generate_runs_details,
 )
 from bublik.core.utils import get_difference
+from bublik.data.models import GlobalConfigs, TestIterationResult
 from bublik.data.serializers import (
     RunCommentSerializer,
     TestIterationResultSerializer,
@@ -98,7 +100,17 @@ class RunViewSet(ModelViewSet):
     @action(detail=True, methods=['get'])
     def stats(self, _request, pk=None):
         requirements = self.request.query_params.get('requirements')
-        return Response({'results': RunService.get_run_stats(pk, requirements)})
+        project_id = TestIterationResult.objects.get(id=pk).project.id
+        return Response(
+            {
+                'results': RunService.get_run_stats(pk, requirements),
+                'default_columns': ConfigServices.getattr_from_global(
+                    GlobalConfigs.PER_CONF.name,
+                    'RUN_STATS_COLUMNS_DEFAULT',
+                    project_id,
+                ),
+            },
+        )
 
     @action(detail=True, methods=['get'])
     def requirements(self, _request, pk=None):


### PR DESCRIPTION
# Info 
Add support for configuring which columns are displayed by default in the run stats table via the main project config. The default value matches the previous hardcoded behaviour. The stats API response is extended to include the resolved default column list alongside the existing results, so the frontend can apply it without hardcoding.

# Overview of changes
## Config
Added configuration parameter to control which run stats table columns are displayed by default.

<img width="953" height="657" alt="Снимок экрана — 2026-06-15 в 21 45 59" src="https://github.com/user-attachments/assets/0b97d55f-49e8-41fa-8665-fa0250312922" />


## API
### GET /bublik/api/v2/<run ID\>/stats/
#### Response data (`default_columns` added):
```
{
    "results": {
        "result_id": 6335,
        "exec_seqno": 1,
        "parent_id": null,
        "type": "pkg",
        "test_id": 1,
        "test_name": "dpdk-ethdev-ts",
        "period": "1781110030s230276-1781119169s529164",
        "path": [
            "dpdk-ethdev-ts"
        ],
        "objective": "",
        "children": [
        ...
        ],
        "stats": {
            "passed": 114,
            "failed": 0,
            "passed_unexpected": 0,
            "failed_unexpected": 0,
            "skipped": 198,
            "skipped_unexpected": 66,
            "abnormal": 0
        },
        "comments": []
    },
    "default_columns": [
        "run",
        "passed",
        "failed",
        "passed_unexpected",
        "failed_unexpected",
        "skipped",
        "skipped_unexpected",
        "abnormal"
    ]
}
```