### PR TITLE
mcp: add compact run and result navigation

### DIFF
--- a/bublik/core/pagination_helpers.py
+++ b/bublik/core/pagination_helpers.py
@@ -85,6 +85,7 @@ class PaginatedResult:
 
         pagination = OrderedDict(
             [
+                ('page', page),
                 ('count', total_count),
                 ('next', f'page={page + 1}' if page < total_pages else None),
                 ('previous', f'page={page - 1}' if page > 1 else None),

--- a/bublik/core/run/dto.py
+++ b/bublik/core/run/dto.py
@@ -127,6 +127,7 @@ class RunSummaryResult:
 
 @dataclass
 class RunListPagination:
+    page: int
     count: int
     next: str | None
     previous: str | None

--- a/bublik/mcp/run/__init__.py
+++ b/bublik/mcp/run/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+from .helpers import _get_run_leaf_results
+from .markdown import render_run_leaf_results, render_run_overview
+
+
+__all__ = [
+    '_get_run_leaf_results',
+    'render_run_leaf_results',
+    'render_run_overview',
+]

--- a/bublik/mcp/run/helpers.py
+++ b/bublik/mcp/run/helpers.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.db.models import Q
+from rest_framework.exceptions import ValidationError
+
+from bublik.core.pagination_helpers import PaginatedResult
+from bublik.core.result import ResultService
+from bublik.core.run.services import RunService
+from bublik.core.run.stats import generate_results_details
+from bublik.data import models
+
+from .models import RunLeafResultsPayload
+
+
+if TYPE_CHECKING:
+    from bublik.core.run.dto import RunStatsResult
+
+
+def _find_stats_node(node: RunStatsResult, result_id: int) -> RunStatsResult | None:
+    if node.result_id == result_id:
+        return node
+
+    for child in node.children:
+        found = _find_stats_node(child, result_id)
+        if found is not None:
+            return found
+
+    return None
+
+
+def _list_unexpected_or_abnormal_results(
+    *,
+    parent_id: int,
+    test_name: str,
+    start_exec_seqno: int,
+    requirements: str | None,
+    page: int | None,
+    page_size: int | None,
+) -> dict:
+    queryset = ResultService.list_results(
+        parent_id=parent_id,
+        test_name=test_name,
+        start_exec_seqno=start_exec_seqno,
+        requirements=requirements,
+    )
+    queryset = queryset.filter(
+        Q(meta_results__meta__type='err') | Q(meta_results__meta__in=models.Meta.abnormal),
+    )
+    result_details = generate_results_details(queryset)
+    return PaginatedResult.paginate_queryset(result_details, page, page_size)
+
+
+def _get_run_leaf_results(
+    leaf_result_id: int,
+    requirements: str | None = None,
+    results: str | None = None,
+    result_properties: str | None = None,
+    page: int | None = None,
+    page_size: int | None = None,
+    unexpected_only: bool = False,
+) -> RunLeafResultsPayload:
+    if unexpected_only and any((results, result_properties)):
+        msg = 'unexpected_only cannot be combined with results or result_properties'
+        raise ValidationError(msg)
+
+    result = ResultService.get_result(leaf_result_id)
+    run_id = result.test_run_id
+    if run_id is None:
+        msg = 'A test leaf result ID from get_run_overview is required'
+        raise ValidationError(msg)
+
+    stats = RunService.get_run_stats(run_id, None)
+    if stats is None:
+        msg = f'Run statistics are unavailable for run {run_id}'
+        raise ValidationError(msg)
+
+    leaf = _find_stats_node(stats, leaf_result_id)
+    if leaf is None:
+        msg = (
+            'Result ID is not an aggregate leaf ID; use the leaf result ID '
+            'shown by get_run_overview'
+        )
+        raise ValidationError(msg)
+    if (
+        leaf.type != 'test'
+        or leaf.children
+        or leaf.parent_id is None
+        or leaf.exec_seqno is None
+    ):
+        msg = 'A test leaf result ID from get_run_overview is required'
+        raise ValidationError(msg)
+
+    if unexpected_only:
+        paginated = _list_unexpected_or_abnormal_results(
+            parent_id=leaf.parent_id,
+            test_name=leaf.test_name,
+            start_exec_seqno=leaf.exec_seqno,
+            requirements=requirements,
+            page=page,
+            page_size=page_size,
+        )
+    else:
+        paginated = ResultService.list_results_paginated(
+            parent_id=leaf.parent_id,
+            test_name=leaf.test_name,
+            start_exec_seqno=leaf.exec_seqno,
+            results=results,
+            result_properties=result_properties,
+            requirements=requirements,
+            page=page,
+            page_size=page_size,
+        )
+    result_rows = [
+        {
+            **row,
+            'classification': 'unexpected' if row['has_error'] else 'expected',
+        }
+        for row in paginated['results']
+    ]
+
+    return RunLeafResultsPayload.model_validate(
+        {
+            'leaf': {
+                'result_id': leaf.result_id,
+                'run_id': run_id,
+                'test_name': leaf.test_name,
+                'path': leaf.path,
+            },
+            'requirements': requirements,
+            'pagination': paginated['pagination'],
+            'results': result_rows,
+        },
+    )

--- a/bublik/mcp/run/markdown.py
+++ b/bublik/mcp/run/markdown.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+import json
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    from bublik.core.run.dto import (
+        RunDetailsResult,
+        RunStatsComment,
+        RunStatsResult,
+        RunStatsValues,
+    )
+
+    from .models import (
+        RunLeafResultsPayload,
+    )
+
+
+def _cell(value: Any) -> str:
+    if value is None or value == '' or (isinstance(value, (dict, list, tuple)) and not value):
+        return '-'
+    if isinstance(value, bool):
+        return 'Yes' if value else 'No'
+    if is_dataclass(value) and not isinstance(value, type):
+        value = asdict(value)
+    if isinstance(value, (dict, list, tuple)):
+        value = json.dumps(
+            value,
+            default=lambda item: (
+                asdict(item) if is_dataclass(item) and not isinstance(item, type) else str(item)
+            ),
+            ensure_ascii=True,
+            sort_keys=True,
+        )
+    return str(value).replace('|', '\\|').replace('\n', '<br>')
+
+
+def _flatten_stats(node: RunStatsResult | None) -> list[RunStatsResult]:
+    if not node:
+        return []
+    descendants = (item for child in node.children for item in _flatten_stats(child))
+    return [node, *descendants]
+
+
+def _comments_text(comments: list[RunStatsComment]) -> str:
+    values = [comment.comment for comment in comments]
+    return '<br>'.join(str(value) for value in values) if values else '-'
+
+
+def _stats_total(stats: RunStatsValues) -> int:
+    return sum(
+        (
+            stats.passed,
+            stats.failed,
+            stats.passed_unexpected,
+            stats.failed_unexpected,
+            stats.skipped,
+            stats.skipped_unexpected,
+            stats.abnormal,
+        ),
+    )
+
+
+def _stats_unexpected(stats: RunStatsValues) -> int:
+    return sum(
+        (
+            stats.passed_unexpected,
+            stats.failed_unexpected,
+            stats.skipped_unexpected,
+            stats.abnormal,
+        ),
+    )
+
+
+def _special_categories(details: RunDetailsResult) -> dict[str, list[str]]:
+    return {category.name: category.values for category in details.special_categories}
+
+
+def render_run_overview(
+    details: RunDetailsResult,
+    source: str | None,
+    stats: RunStatsResult | None,
+    requirements: str | None,
+    unexpected_only: bool = False,
+) -> str:
+    compromised = details.compromised
+    rows = [
+        ('Run ID', details.id),
+        ('Project', details.project_name),
+        ('Status', details.status),
+        ('Status by NOK', details.status_by_nok),
+        ('Conclusion', details.conclusion),
+        ('Conclusion reason', details.conclusion_reason),
+        ('Start', details.start),
+        ('Finish', details.finish),
+        ('Duration', details.duration),
+        ('Main package', details.main_package),
+        ('Source', source),
+        ('Requirements', requirements or 'none'),
+        ('Result view', 'unexpected leaves' if unexpected_only else 'all results'),
+        ('Compromised', compromised.status if compromised is not None else None),
+        ('Compromised comment', compromised.comment if compromised is not None else None),
+        (
+            'Compromised bug',
+            (compromised.bug_url or compromised.bug_id) if compromised is not None else None,
+        ),
+        ('Important tags', details.important_tags),
+        ('Relevant tags', details.relevant_tags),
+        ('Branches', details.branches),
+        ('Revisions', details.revisions),
+        ('Labels', details.labels),
+        ('Configuration', details.configuration),
+        ('Special categories', _special_categories(details)),
+    ]
+    lines = [
+        f'# Run {_cell(details.id)} Overview',
+        '',
+        '| Field | Value |',
+        '|---|---|',
+        *(f'| {_cell(name)} | {_cell(value)} |' for name, value in rows),
+        '',
+        '## Result Statistics',
+        '',
+        (
+            '| Result ID | Type | Path | Objective | Comments | Passed | Failed | '
+            'Passed NOK | Failed NOK | Skipped | Skipped NOK | Abnormal | Total | NOK |'
+        ),
+        '|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|',
+    ]
+
+    stat_nodes = _flatten_stats(stats)
+    if unexpected_only:
+        stat_nodes = [
+            node
+            for node in stat_nodes
+            if not node.children and _stats_unexpected(node.stats) > 0
+        ]
+
+    for node in stat_nodes:
+        node_stats = node.stats
+        result_type = {'pkg': 'package', 'session': 'session', 'test': 'test'}.get(
+            node.type,
+            node.type,
+        )
+        lines.append(
+            '| {result_id} | {result_type} | {path} | {objective} | {comments} | '
+            '{passed} | {failed} | '
+            '{passed_nok} | {failed_nok} | {skipped} | {skipped_nok} | '
+            '{abnormal} | {total} | {nok} |'.format(
+                result_id=_cell(node.result_id),
+                result_type=_cell(result_type),
+                path=_cell(' / '.join(node.path)),
+                objective=_cell(node.objective),
+                comments=_cell(_comments_text(node.comments)),
+                passed=node_stats.passed,
+                failed=node_stats.failed,
+                passed_nok=node_stats.passed_unexpected,
+                failed_nok=node_stats.failed_unexpected,
+                skipped=node_stats.skipped,
+                skipped_nok=node_stats.skipped_unexpected,
+                abnormal=node_stats.abnormal,
+                total=_stats_total(node_stats),
+                nok=_stats_unexpected(node_stats),
+            ),
+        )
+
+    if not stat_nodes:
+        lines.append(
+            '| - | - | - | - | - | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |',
+        )
+        if unexpected_only:
+            lines.extend(
+                [
+                    '',
+                    '*No unexpected or abnormal result leaves found.*',
+                ],
+            )
+
+    lines.extend(
+        [
+            '',
+            '*Use a test row Result ID with `get_run_leaf_results` to inspect '
+            'its concrete executions.*',
+        ],
+    )
+    return '\n'.join(lines)
+
+
+def _expected_result_text(expected_results) -> str:
+    values = [item.result_type for item in expected_results if item.result_type]
+    return ', '.join(values) if values else '-'
+
+
+def render_run_leaf_results(payload: RunLeafResultsPayload) -> str:
+    leaf = payload.leaf
+    pagination = payload.pagination
+    lines = [
+        f'# Leaf Results: {_cell(leaf.test_name)}',
+        '',
+        f'Path: `{_cell(" / ".join(leaf.path))}`',
+        f'Aggregate leaf: `{_cell(leaf.result_id)}`',
+        f'Run: `{_cell(leaf.run_id)}`',
+        f'Requirements: `{_cell(payload.requirements or "none")}`',
+        '',
+        (
+            '| Result ID | Parameters | Start | Obtained | Expected | '
+            'Classification | Verdicts | Artifacts |'
+        ),
+        '|---:|---|---|---|---|---|---|---|',
+    ]
+    for result in payload.results:
+        obtained = result.obtained_result
+        lines.append(
+            f'| {_cell(result.result_id)} | '
+            f'{_cell("<br>".join(result.parameters))} | '
+            f'{_cell(result.start)} | '
+            f'{_cell(obtained.result_type)} | '
+            f'{_cell(_expected_result_text(result.expected_results))} | '
+            f'{_cell(result.classification)} | '
+            f'{_cell("<br>".join(obtained.verdicts))} | '
+            f'{_cell("<br>".join(result.artifacts))} |',
+        )
+    if not payload.results:
+        lines.append('| - | - | - | - | - | - | - | - |')
+
+    lines.extend(
+        [
+            '',
+            (
+                f'*Page {pagination.page} | {pagination.count} results | '
+                f'previous: {pagination.previous or "-"} | '
+                f'next: {pagination.next or "-"}*'
+            ),
+        ],
+    )
+    return '\n'.join(lines)

--- a/bublik/mcp/run/models.py
+++ b/bublik/mcp/run/models.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003 - Pydantic needs this at runtime.
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RunLeafIdentity(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    result_id: int
+    run_id: int
+    test_name: str
+    path: list[str]
+
+
+class RunLeafPagination(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    page: int = Field(ge=1)
+    count: int = Field(ge=0)
+    next: str | None
+    previous: str | None
+
+
+class RunExpectedKey(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    name: str
+    url: str | None
+
+
+class RunExpectedResult(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    result_type: str
+    verdicts: list[str]
+    keys: list[RunExpectedKey]
+
+
+class RunObtainedResult(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    result_type: str | None
+    verdicts: list[str]
+
+
+class RunLeafResult(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    name: str
+    result_id: int
+    run_id: int
+    project_id: int
+    project_name: str
+    iteration_id: int
+    start: datetime
+    obtained_result: RunObtainedResult
+    expected_results: list[RunExpectedResult]
+    artifacts: list[str]
+    parameters: list[str]
+    comments: list[str]
+    requirements: list[str]
+    has_error: bool
+    has_measurements: bool
+    classification: Literal['expected', 'unexpected']
+
+
+class RunLeafResultsPayload(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    leaf: RunLeafIdentity
+    requirements: str | None
+    pagination: RunLeafPagination
+    results: list[RunLeafResult]

--- a/bublik/mcp/tools.py
+++ b/bublik/mcp/tools.py
@@ -21,11 +21,10 @@ from bublik.core.server import ServerService
 from bublik.core.tree.services import TreeService
 from bublik.interfaces.api_v2.run.serializers import (
     serialize_paginated_run_summary_results,
-    serialize_run_details,
-    serialize_run_stats_result,
 )
 from bublik.mcp.models import JsonLog
 from bublik.mcp.processor import LogProcessor
+from bublik.mcp.run import _get_run_leaf_results, render_run_leaf_results, render_run_overview
 
 
 if TYPE_CHECKING:
@@ -54,75 +53,92 @@ def register_tools(mcp: FastMCP):  # noqa: C901
     """
 
     @mcp.tool()
-    async def get_run_details(run_id: int) -> dict:
-        """
-        Get detailed information about a test run.
-
-        Args:
-            run_id: The ID of the test run
-
-        Returns:
-            Dictionary with full run details including metadata, stats, etc.
-        """
-        return serialize_run_details(await sync_to_async(RunService.get_run_details)(run_id))
-
-    @mcp.tool()
-    async def get_run_status(run_id: int) -> str:
-        """
-        Get the status of a test run.
-
-        Args:
-            run_id: The ID of the test run
-
-        Returns:
-            Status string for the run (e.g., 'passed', 'failed', 'skipped')
-        """
-        return await sync_to_async(RunService.get_run_status)(run_id)
-
-    @mcp.tool()
-    async def get_run_stats(
+    async def get_run_overview(
         run_id: int,
         requirements: str | None = None,
-    ) -> dict:
+        unexpected_only: bool = False,
+    ) -> str:
         """
-        Get statistics for a test run.
+        Get a complete Markdown overview of a test run.
+
+        The overview combines run metadata, status, conclusion, source,
+        compromised details, and the aggregate result statistics tree. Each
+        test row includes a Result ID that can be passed to
+        get_run_leaf_results for concrete executions.
 
         Args:
             run_id: The ID of the test run
-            requirements: Optional requirements filter
+            requirements: Optional semicolon-separated requirements filter
+            unexpected_only: Return only test leaves containing unexpected or
+                abnormal results
 
         Returns:
-            Dictionary with run statistics including pass/fail counts
+            Markdown document containing run details and aggregate statistics
         """
-        return serialize_run_stats_result(
-            await sync_to_async(RunService.get_run_stats)(run_id, requirements),
+        details, source, stats = await sync_to_async(
+            lambda: (
+                RunService.get_run_details(run_id),
+                RunService.get_run_source(run_id),
+                RunService.get_run_stats(run_id, requirements),
+            ),
+        )()
+
+        return render_run_overview(
+            details,
+            source,
+            stats,
+            requirements,
+            unexpected_only,
         )
 
     @mcp.tool()
-    async def get_run_source(run_id: int) -> str:
+    async def get_run_leaf_results(
+        leaf_result_id: int,
+        requirements: str | None = None,
+        results: str | None = None,
+        result_properties: str | None = None,
+        page: int | None = None,
+        page_size: int | None = None,
+        unexpected_only: bool = False,
+    ) -> str:
         """
-        Get the source URL for a test run.
+        Get paginated executions represented by a test leaf in a run overview.
+
+        Pass a test Result ID shown by get_run_overview, not an individual
+        execution ID. For the common failure-investigation workflow, set
+        unexpected_only to true to return only unexpected or abnormal executions.
+        Use the advanced requirements, results, and result_properties filters to
+        narrow further. requirements composes with unexpected_only; results and
+        result_properties are mutually exclusive with it (they overlap with the
+        unexpected/abnormal classification). With no toggle or filters, all
+        executions represented by the leaf are returned.
 
         Args:
-            run_id: The ID of the test run
+            leaf_result_id: Aggregate test Result ID shown by get_run_overview
+            requirements: Optional semicolon-separated requirement names
+            results: Optional semicolon-separated obtained result statuses
+                (e.g., 'PASSED;FAILED;SKIPPED;KILLED;CORED;FAKED;INCOMPLETE')
+            result_properties: Optional semicolon-separated result properties
+                (e.g., 'expected;unexpected;not_run')
+            page: Page number (default: 1)
+            page_size: Items per page (default: 25, max: 10000)
+            unexpected_only: Return only unexpected or abnormal executions.
+                Can be combined with requirements; cannot be combined with
+                results or result_properties
 
         Returns:
-            Source URL string
+            Markdown table with the matching concrete executions and pagination
         """
-        return await sync_to_async(RunService.get_run_source)(run_id)
-
-    @mcp.tool()
-    async def get_run_compromised(run_id: int) -> bool:
-        """
-        Get the compromised status of a test run.
-
-        Args:
-            run_id: The ID of the test run
-
-        Returns:
-            True if the run is compromised, False otherwise
-        """
-        return await sync_to_async(RunService.get_run_compromised)(run_id)
+        payload = await sync_to_async(_get_run_leaf_results)(
+            leaf_result_id=leaf_result_id,
+            requirements=requirements,
+            results=results,
+            result_properties=result_properties,
+            page=page,
+            page_size=page_size,
+            unexpected_only=unexpected_only,
+        )
+        return render_run_leaf_results(payload)
 
     @mcp.tool()
     async def get_result_details(result_id: int) -> dict:
@@ -149,48 +165,6 @@ def register_tools(mcp: FastMCP):  # noqa: C901
             Dictionary with artifacts and verdicts lists
         """
         return await sync_to_async(ResultService.get_result_artifacts_and_verdicts)(result_id)
-
-    @mcp.tool()
-    async def list_results(
-        parent_id: int,
-        test_name: str,
-        start_exec_seqno: str,
-        results: str | None = None,
-        result_properties: str | None = None,
-        requirements: str | None = None,
-        page: int | None = None,
-        page_size: int | None = None,
-    ) -> dict:
-        """
-        List test results with filtering.
-
-        Args:
-            parent_id: Filter by parent package ID
-            test_name: Filter by test name
-            start_exec_seqno: Retain only the consecutive sequence of results
-                starting from the specified execution number, based on the global
-                run sequence
-            results: Semicolon-separated result statuses
-                (e.g., 'PASSED;FAILED;SKIPPED;KILLED;CORED;FAKED;INCOMPLETE')
-            result_properties: Semicolon-separated result properties
-                (e.g., 'expected;unexpected;not_run')
-            requirements: Semicolon-separated requirement names
-            page: Page number (default: 1)
-            page_size: Items per page (default: 25, max: 10000)
-
-        Returns:
-            Dictionary with pagination metadata and result details
-        """
-        return await sync_to_async(ResultService.list_results_paginated)(
-            parent_id=parent_id,
-            test_name=test_name,
-            start_exec_seqno=start_exec_seqno,
-            results=results,
-            result_properties=result_properties,
-            requirements=requirements,
-            page=page,
-            page_size=page_size,
-        )
 
     # Project tools
 


### PR DESCRIPTION
Stacked on top of https://github.com/ts-factory/bublik/pull/324

---

Replace the fragmented run metadata tools and the ambiguous direct-child
`list_results` interface with two validated Markdown workflows for MCP clients.

## What changed

This PR introduces two higher-level run navigation tools:

- `get_run_overview`
- `get_run_leaf_results`

Together they replace the previous flow where clients had to call separate run
metadata/stat/source tools and manually reconstruct how to navigate from a run
tree node to concrete test executions.

## New tools

### `get_run_overview`

Returns a complete Markdown overview for a run, including:

- run metadata
- status and conclusion
- source URL
- compromised details
- recursive result statistics tree
- aggregate Result IDs for test leaves

The tool also supports:

- `requirements`: semicolon-separated requirement filter
- `unexpected_only`: return only leaf tests containing unexpected or abnormal results

Each test row includes a Result ID that can be passed directly to
`get_run_leaf_results`.

### `get_run_leaf_results`

Returns paginated concrete executions represented by one test leaf from
`get_run_overview`.

The input is intentionally an aggregate test Result ID from the overview, not an
individual execution ID. The tool validates that the ID points to a real test
leaf before resolving executions.

It supports two usage modes:

- `unexpected_only=true`: common failure-investigation mode, returning only
  unexpected or abnormal executions
- advanced filters:
  - `requirements`
  - `results`, for example `PASSED;FAILED;SKIPPED;KILLED;CORED;FAKED;INCOMPLETE`
  - `result_properties`, for example `expected;unexpected;not_run`

`unexpected_only` is mutually exclusive with the advanced filters.

## Why this is better

The old MCP interface exposed lower-level pieces of the UI model. Clients had to
combine run details, source, stats, and direct-child result listing themselves,
while also knowing how Bublik lazy-loads the run tree.

The new flow is explicit:

1. Call `get_run_overview(run_id)` to inspect the run and find interesting test leaves.
2. Pick a test row Result ID.
3. Call `get_run_leaf_results(leaf_result_id)` to inspect concrete executions.

This makes MCP usage more reliable and cheaper for large runs because clients no
longer need to fetch or reason over unrelated execution details.

## Token impact

Estimated token count changes:

- Full run stats: ~26,000 tokens -> ~10,000 tokens
- Unexpected-only run stats leaves: ~26,000 tokens -> ~2,000 tokens

## Validation and rendering

The new run payloads are validated with strict Pydantic models before Markdown
rendering. This keeps the MCP output compact and human-readable while still
catching unexpected service payload changes early.

Issue: https://github.com/ts-factory/bublik/issues/326
Issue: https://github.com/ts-factory/bublik/issues/327
