### PR TITLE
Run: make compromised status checks return consistent shapes

### DIFF
--- a/bublik/core/run/compromised.py
+++ b/bublik/core/run/compromised.py
@@ -37,6 +37,9 @@ def get_compromised_details(run):
             }
         return {
             'status': False,
+            'comment': None,
+            'bug_id': None,
+            'bug_url': None,
         }
     return None
 

--- a/bublik/core/run/services.py
+++ b/bublik/core/run/services.py
@@ -127,7 +127,7 @@ class RunService:
         return get_sources(run)
 
     @staticmethod
-    def get_run_compromised(run_id: int) -> dict:
+    def get_run_compromised(run_id: int) -> bool:
         """
         Get compromised status for a run.
 
@@ -135,13 +135,13 @@ class RunService:
             run_id: The ID of the test run
 
         Returns:
-            Dictionary with compromised status data
+            True if the run is compromised, False otherwise
         """
         run = RunService.get_run(run_id)
-        compromised_data = is_run_compromised(run)
-        if not compromised_data:
-            compromised_data = {'compromised': False}
-        return compromised_data
+        is_compromised = is_run_compromised(run)
+        if not is_compromised:
+            return False
+        return is_compromised
 
     @staticmethod
     def mark_run_compromised(

--- a/bublik/mcp/tools.py
+++ b/bublik/mcp/tools.py
@@ -113,7 +113,7 @@ def register_tools(mcp: FastMCP):  # noqa: C901
             run_id: The ID of the test run
 
         Returns:
-            Dictionary with compromised status data including comment and bug ID
+            True if the run is compromised, False otherwise
         """
         return await sync_to_async(RunService.get_run_compromised)(run_id)
 


### PR DESCRIPTION
Two of the compromised-status helpers returned inconsistent shapes depending on whether the run was compromised or not.

1. `get_run_compromised()` was typed as `-> dict` but only ever returned a bare `bool` for the positive case and a `dict` for the negative case. Unify it to consistently return `bool`.

2. `get_compromised_details()` returned different key sets depending on status — `status`, `comment`, `bug_id`, `bug_url` when compromised, but only `status` otherwise. Add the missing keys (as `None`) to the negative case so callers always get the same shape.

With both fixed, callers can rely on a single, predictable shape regardless of compromised status, with no special-casing needed.
