### PR TITLE
run/results: align API v2 OpenAPI schemas with run/result responses

### DIFF
--- a/bublik/core/result/services.py
+++ b/bublik/core/result/services.py
@@ -96,6 +96,7 @@ class ResultService:
         Returns:
             Dictionary with artifacts and verdicts lists
         """
+        ResultService.get_result(result_id)
         result_metas = models.Meta.objects.filter(metaresult__result__id=result_id)
         return {
             'artifacts': list(result_metas.filter(type='artifact').values()),

--- a/bublik/interfaces/api_v2/result/schemas.py
+++ b/bublik/interfaces/api_v2/result/schemas.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+
+from bublik.interfaces.api_v2.errors.serializers import ErrorResponseSerializer
+from bublik.interfaces.api_v2.result.serializers import (
+    ResultArtifactsAndVerdictsResponseSerializer,
+    ResultListQuerySerializer,
+    ResultListResponseSerializer,
+    ResultMeasurementsResponseSerializer,
+    ResultRetrieveResponseSerializer,
+)
+
+
+RESULT_TAG = 'Results'
+
+
+result_viewset_schema = extend_schema_view(
+    retrieve=extend_schema(
+        summary='Get result details',
+        description="""
+        Returns full details for a single test iteration result, including
+        expected and obtained results, artifacts, parameters, comments,
+        requirements, error state, and measurement availability.
+        """,
+        responses={
+            200: OpenApiResponse(
+                response=ResultRetrieveResponseSerializer,
+                description='Result details were successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Result was not found',
+            ),
+        },
+        tags=[RESULT_TAG],
+    ),
+    list=extend_schema(
+        summary='List results',
+        description="""
+        Returns test iteration results matching the provided parent, test name,
+        execution sequence, result status, classification, and requirement
+        filters.
+        """,
+        parameters=[ResultListQuerySerializer],
+        responses={
+            200: OpenApiResponse(
+                response=ResultListResponseSerializer,
+                description='Results were successfully retrieved',
+            ),
+            400: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Result filter validation failed',
+            ),
+        },
+        tags=[RESULT_TAG],
+    ),
+    artifacts_and_verdicts=extend_schema(
+        summary='Get result artifacts and verdicts',
+        description="""
+        Returns artifact and verdict meta values for a result.
+        """,
+        responses={
+            200: OpenApiResponse(
+                response=ResultArtifactsAndVerdictsResponseSerializer,
+                description='Artifacts and verdicts were successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Result was not found',
+            ),
+        },
+        tags=[RESULT_TAG],
+    ),
+    measurements=extend_schema(
+        summary='Get result measurements',
+        description="""
+        Returns measurement chart and table data for a result.
+        """,
+        responses={
+            200: OpenApiResponse(
+                response=ResultMeasurementsResponseSerializer,
+                description='Result measurements were successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Result was not found',
+            ),
+        },
+        tags=[RESULT_TAG],
+    ),
+)

--- a/bublik/interfaces/api_v2/result/serializers.py
+++ b/bublik/interfaces/api_v2/result/serializers.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+from drf_spectacular.utils import extend_schema_serializer
+from rest_framework import serializers
+
+
+class ResultListQuerySerializer(serializers.Serializer):
+    parent_id = serializers.IntegerField(required=False)
+    test_name = serializers.CharField(required=False)
+    start_exec_seqno = serializers.IntegerField(required=False)
+    results = serializers.CharField(required=False)
+    result_properties = serializers.CharField(required=False)
+    requirements = serializers.CharField(required=False)
+
+
+class ResultKeySerializer(serializers.Serializer):
+    name = serializers.CharField()
+    url = serializers.CharField(allow_null=True)
+
+
+class ExpectedResultSerializer(serializers.Serializer):
+    result_type = serializers.CharField(allow_null=True)
+    verdicts = serializers.ListField(child=serializers.CharField())
+    keys = ResultKeySerializer(many=True)
+
+
+class ObtainedResultSerializer(serializers.Serializer):
+    result_type = serializers.CharField(allow_null=True)
+    verdicts = serializers.ListField(child=serializers.CharField())
+
+
+class ResultDetailsSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    result_id = serializers.IntegerField()
+    run_id = serializers.IntegerField()
+    project_id = serializers.IntegerField()
+    project_name = serializers.CharField()
+    iteration_id = serializers.IntegerField()
+    start = serializers.DateTimeField(allow_null=True)
+    obtained_result = ObtainedResultSerializer()
+    expected_results = ExpectedResultSerializer(many=True)
+    artifacts = serializers.ListField(child=serializers.CharField())
+    parameters = serializers.ListField(child=serializers.CharField())
+    comments = serializers.ListField(child=serializers.CharField())
+    requirements = serializers.ListField(child=serializers.CharField())
+    has_error = serializers.BooleanField()
+    has_measurements = serializers.BooleanField()
+
+
+@extend_schema_serializer(many=False)
+class ResultListResponseSerializer(serializers.Serializer):
+    results = ResultDetailsSerializer(many=True)
+
+
+class ResultRetrieveResponseSerializer(serializers.Serializer):
+    result = ResultDetailsSerializer()
+
+
+class MetaValueSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField(allow_null=True)
+    type = serializers.CharField()
+    value = serializers.CharField(allow_null=True)
+    hash = serializers.CharField()
+    comment = serializers.CharField(allow_null=True)
+
+
+class ResultArtifactsAndVerdictsResponseSerializer(serializers.Serializer):
+    artifacts = MetaValueSerializer(many=True)
+    verdicts = MetaValueSerializer(many=True)
+
+
+class ResultMeasurementsResponseSerializer(serializers.Serializer):
+    run_id = serializers.IntegerField(allow_null=True)
+    iteration_id = serializers.IntegerField()
+    charts = serializers.ListField(child=serializers.DictField())
+    tables = serializers.ListField(child=serializers.DictField())

--- a/bublik/interfaces/api_v2/result/views.py
+++ b/bublik/interfaces/api_v2/result/views.py
@@ -11,9 +11,8 @@ from bublik.core.result import ResultService
 from bublik.core.run.stats import (
     generate_results_details,
 )
-from bublik.data.serializers import (
-    TestIterationResultSerializer,
-)
+from bublik.data.serializers import TestIterationResultSerializer
+from bublik.interfaces.api_v2.result.schemas import result_viewset_schema
 
 
 __all__ = [
@@ -21,6 +20,7 @@ __all__ = [
 ]
 
 
+@result_viewset_schema
 class ResultViewSet(ModelViewSet):
     serializer_class = TestIterationResultSerializer
     filter_backends: ClassVar[list] = []

--- a/bublik/interfaces/api_v2/run/schemas.py
+++ b/bublik/interfaces/api_v2/run/schemas.py
@@ -1,0 +1,331 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 OKTET Labs Ltd. All rights reserved.
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+
+from bublik.interfaces.api_v2.errors.serializers import ErrorResponseSerializer
+from bublik.interfaces.api_v2.run.serializers import (
+    DropCacheRequestSerializer,
+    DropCacheResponseSerializer,
+    MarkRunCompromisedRequestSerializer,
+    MarkRunCompromisedResponseSerializer,
+    RunChartsQuerySerializer,
+    RunChartsResponseSerializer,
+    RunCommentRequestSerializer,
+    RunCommentResponseSerializer,
+    RunCommentValueResponseSerializer,
+    RunDetailsResponseSerializer,
+    RunListItemSerializer,
+    RunListQuerySerializer,
+    RunRequirementsResponseSerializer,
+    RunSourceResponseSerializer,
+    RunStatsQuerySerializer,
+    RunStatsResponseSerializer,
+    RunStatusResponseSerializer,
+    UnmarkRunCompromisedResponseSerializer,
+)
+
+
+RUN_TAG = 'Runs'
+
+
+run_viewset_schema = extend_schema_view(
+    list=extend_schema(
+        summary='List runs',
+        description="""
+        Returns a paginated list of test runs with project, timing, status,
+        classification, metadata, tag, and summary statistics fields.
+        Supports date, project, status, metadata, and expression filters.
+        """,
+        parameters=[RunListQuerySerializer],
+        responses={
+            200: OpenApiResponse(
+                response=RunListItemSerializer(many=True),
+                description='Runs were successfully retrieved',
+            )
+        },
+        tags=[RUN_TAG],
+    ),
+    charts=extend_schema(
+        summary='Get run charts',
+        description="""
+        Returns run chart buckets grouped by day or week. Each bucket contains
+        aggregated test counters, passrate, and run IDs grouped by conclusion.
+        """,
+        parameters=[RunChartsQuerySerializer],
+        responses={
+            200: OpenApiResponse(
+                response=RunChartsResponseSerializer,
+                description='Run charts were successfully retrieved',
+            ),
+            400: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Invalid chart grouping was provided',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    drop_cache=extend_schema(
+        summary='Drop run cache',
+        description="""
+        Deletes selected cache entries for every run matching the current run
+        filters and returns identifiers of affected runs.
+        """,
+        request=DropCacheRequestSerializer,
+        responses={
+            200: OpenApiResponse(
+                response=DropCacheResponseSerializer,
+                description='Run cache entries were successfully deleted',
+            ),
+            400: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Unknown cache key was provided',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    nok_distribution=extend_schema(
+        summary='Get NOK distribution',
+        description="""
+        Returns a boolean NOK flag for each test result in the run.
+        """,
+        responses={
+            200: OpenApiResponse(
+                response={'type': 'array', 'items': {'type': 'boolean'}},
+                description='NOK distribution was successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    details=extend_schema(
+        summary='Get run details',
+        description="""
+        Returns full details for a single run, including metadata, tags,
+        branches, revisions, labels, configuration, status, and conclusion.
+        """,
+        responses={
+            200: OpenApiResponse(
+                response=RunDetailsResponseSerializer,
+                description='Run details were successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    stats=extend_schema(
+        summary='Get run statistics',
+        description="""
+        Returns the run result tree with aggregated pass/fail statistics and
+        comments. The optional requirements filter limits statistics to tests
+        matching the provided requirement list.
+        """,
+        parameters=[RunStatsQuerySerializer],
+        responses={
+            200: OpenApiResponse(
+                response=RunStatsResponseSerializer,
+                description='Run statistics were successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    requirements=extend_schema(
+        summary='List run requirements',
+        description="""
+        Returns sorted requirement values associated with a run.
+        """,
+        responses={
+            200: OpenApiResponse(
+                response=RunRequirementsResponseSerializer,
+                description='Run requirements were successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    source=extend_schema(
+        summary='Get run source URL',
+        description="""
+        Returns the external source URL associated with a run.
+        """,
+        responses={
+            200: OpenApiResponse(
+                response=RunSourceResponseSerializer,
+                description='Run source URL was successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    status=extend_schema(
+        summary='Get run status',
+        description="""
+        Returns the configured status value for a run.
+        """,
+        responses={
+            200: OpenApiResponse(
+                response=RunStatusResponseSerializer,
+                description='Run status was successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    compromised=extend_schema(
+        summary='Get run compromised status',
+        description="""
+        Returns whether a run is marked as compromised.
+        """,
+        responses={
+            200: OpenApiResponse(
+                response={'type': 'boolean'},
+                description='Run compromised status was successfully retrieved',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+    comment=extend_schema(
+        summary='Get run comment',
+        description="""
+        Returns the current run comment, or null if no comment exists.
+        """,
+        responses={
+            200: OpenApiResponse(
+                response=RunCommentValueResponseSerializer,
+                description='Run comment was successfully retrieved',
+            ),
+            400: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Multiple comments were found for the run',
+            ),
+            404: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description='Run was not found',
+            ),
+        },
+        tags=[RUN_TAG],
+    ),
+)
+
+
+mark_compromised_schema = extend_schema(
+    summary='Mark run as compromised',
+    description="""
+    Marks a run as compromised using a required comment and optional bug
+    reference data.
+    """,
+    request=MarkRunCompromisedRequestSerializer,
+    responses={
+        200: OpenApiResponse(
+            response=MarkRunCompromisedResponseSerializer,
+            description='Run was successfully marked as compromised',
+        ),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description='Compromised request validation failed',
+        ),
+        404: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description='Run was not found',
+        ),
+    },
+    tags=[RUN_TAG],
+)
+
+
+unmark_compromised_schema = extend_schema(
+    summary='Unmark run as compromised',
+    description="""
+    Removes the compromised marker from a run.
+    """,
+    responses={
+        200: OpenApiResponse(
+            response=UnmarkRunCompromisedResponseSerializer,
+            description='Run was successfully unmarked as compromised',
+        ),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description='Run could not be unmarked',
+        ),
+    },
+    tags=[RUN_TAG],
+)
+
+
+create_comment_schema = extend_schema(
+    summary='Create run comment',
+    description="""
+    Creates or replaces a run comment.
+    """,
+    request=RunCommentRequestSerializer,
+    responses={
+        201: OpenApiResponse(
+            response=RunCommentResponseSerializer,
+            description='Run comment was successfully created',
+        ),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description='Run comment request validation failed',
+        ),
+    },
+    tags=[RUN_TAG],
+)
+
+
+update_comment_schema = extend_schema(
+    summary='Update run comment',
+    description="""
+    Creates or replaces a run comment.
+    """,
+    request=RunCommentRequestSerializer,
+    responses={
+        200: OpenApiResponse(
+            response=RunCommentResponseSerializer,
+            description='Run comment was successfully updated',
+        ),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description='Run comment request validation failed',
+        ),
+    },
+    tags=[RUN_TAG],
+)
+
+
+delete_comment_schema = extend_schema(
+    summary='Delete run comment',
+    description="""
+    Deletes the current run comment.
+    """,
+    responses={
+        204: OpenApiResponse(description='Run comment was successfully deleted'),
+        400: OpenApiResponse(
+            response=ErrorResponseSerializer,
+            description='No comment exists for the run',
+        ),
+    },
+    tags=[RUN_TAG],
+)

--- a/bublik/interfaces/api_v2/run/serializers.py
+++ b/bublik/interfaces/api_v2/run/serializers.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from rest_framework import serializers
+
 
 if TYPE_CHECKING:
     from bublik.core.run.dto import (
@@ -20,6 +22,239 @@ if TYPE_CHECKING:
         RunSummaryResult,
         RunSummaryStats,
     )
+
+
+class PaginationSerializer(serializers.Serializer):
+    count = serializers.IntegerField()
+    next = serializers.CharField(allow_null=True)
+    previous = serializers.CharField(allow_null=True)
+
+
+class RunListQuerySerializer(serializers.Serializer):
+    start_date = serializers.DateField(required=False)
+    finish_date = serializers.DateField(required=False)
+    project = serializers.IntegerField(required=False)
+    run_status = serializers.CharField(required=False)
+    run_metas = serializers.CharField(required=False)
+    tag_expr = serializers.CharField(required=False)
+    label_expr = serializers.CharField(required=False)
+    revision_expr = serializers.CharField(required=False)
+    branch_expr = serializers.CharField(required=False)
+
+
+class RunChartsQuerySerializer(serializers.Serializer):
+    group_by = serializers.ChoiceField(
+        choices=('day', 'week'),
+        required=False,
+    )
+
+
+class DropCacheRequestSerializer(serializers.Serializer):
+    keys = serializers.ListField(child=serializers.CharField())
+
+
+class DropCacheResponseSerializer(serializers.Serializer):
+    results = serializers.ListField(child=serializers.IntegerField())
+
+
+class CompromisedDetailsSerializer(serializers.Serializer):
+    status = serializers.BooleanField()
+    comment = serializers.CharField(allow_null=True, required=False)
+    bug_id = serializers.CharField(allow_null=True, required=False)
+    bug_url = serializers.CharField(allow_null=True, required=False)
+
+
+class RevisionSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    value = serializers.CharField()
+    url = serializers.CharField(allow_blank=True)
+
+
+class RunSummaryStatsSerializer(serializers.Serializer):
+    tests_total = serializers.IntegerField()
+    tests_total_plan_percent = serializers.IntegerField(allow_null=True)
+    tests_total_ok = serializers.IntegerField()
+    tests_total_ok_percent = serializers.IntegerField()
+    tests_total_nok = serializers.IntegerField()
+    tests_total_nok_percent = serializers.IntegerField()
+
+
+class RunListItemSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    project_id = serializers.IntegerField()
+    project_name = serializers.CharField()
+    start = serializers.DateTimeField(allow_null=True)
+    finish = serializers.DateTimeField(allow_null=True)
+    duration = serializers.DurationField(allow_null=True)
+    status = serializers.CharField(allow_null=True)
+    status_by_nok = serializers.CharField()
+    compromised = serializers.BooleanField(allow_null=True)
+    conclusion = serializers.CharField()
+    conclusion_reason = serializers.CharField(allow_null=True)
+    metadata = serializers.ListField(child=serializers.CharField())
+    important_tags = serializers.ListField(child=serializers.CharField())
+    relevant_tags = serializers.ListField(child=serializers.CharField())
+    stats = RunSummaryStatsSerializer(allow_null=True)
+
+
+class RunDetailsResponseSerializer(serializers.Serializer):
+    project_id = serializers.IntegerField()
+    project_name = serializers.CharField()
+    id = serializers.IntegerField()
+    start = serializers.DateTimeField(allow_null=True)
+    finish = serializers.DateTimeField(allow_null=True)
+    duration = serializers.DurationField(allow_null=True)
+    main_package = serializers.CharField(allow_null=True)
+    status = serializers.CharField(allow_null=True)
+    status_by_nok = serializers.CharField()
+    compromised = CompromisedDetailsSerializer(allow_null=True)
+    conclusion = serializers.CharField()
+    conclusion_reason = serializers.CharField(allow_null=True)
+    important_tags = serializers.ListField(child=serializers.CharField())
+    relevant_tags = serializers.ListField(child=serializers.CharField())
+    branches = serializers.ListField(child=serializers.CharField())
+    revisions = RevisionSerializer(many=True)
+    labels = serializers.ListField(child=serializers.CharField())
+    special_categories = serializers.DictField(
+        child=serializers.ListField(child=serializers.CharField()),
+    )
+    configuration = serializers.CharField(allow_null=True)
+
+
+class RunStatsQuerySerializer(serializers.Serializer):
+    requirements = serializers.CharField(required=False)
+
+
+class RunStatsValuesSerializer(serializers.Serializer):
+    passed = serializers.IntegerField()
+    failed = serializers.IntegerField()
+    passed_unexpected = serializers.IntegerField()
+    failed_unexpected = serializers.IntegerField()
+    skipped = serializers.IntegerField()
+    skipped_unexpected = serializers.IntegerField()
+    abnormal = serializers.IntegerField()
+
+
+class RunStatsCommentSerializer(serializers.Serializer):
+    comment_id = serializers.CharField()
+    updated = serializers.CharField()
+    serial = serializers.CharField()
+    comment = serializers.CharField()
+
+
+class RunStatsNodeSerializer(serializers.Serializer):
+    result_id = serializers.IntegerField()
+    exec_seqno = serializers.IntegerField()
+    parent_id = serializers.IntegerField(allow_null=True)
+    type = serializers.CharField()
+    test_id = serializers.IntegerField()
+    test_name = serializers.CharField()
+    period = serializers.CharField()
+    path = serializers.ListField(child=serializers.CharField())
+    objective = serializers.CharField(allow_blank=True)
+    children = serializers.ListField(
+        child=serializers.DictField(),
+        help_text='Child nodes with the same structure.',
+    )
+    stats = RunStatsValuesSerializer()
+    comments = RunStatsCommentSerializer(many=True)
+
+
+class RunStatsResponseSerializer(serializers.Serializer):
+    results = RunStatsNodeSerializer(allow_null=True)
+    default_columns = serializers.ListField(child=serializers.CharField())
+
+
+class RunRequirementsResponseSerializer(serializers.Serializer):
+    requirements = serializers.ListField(child=serializers.CharField())
+
+
+class RunSourceResponseSerializer(serializers.Serializer):
+    url = serializers.CharField(allow_null=True)
+
+
+class RunStatusResponseSerializer(serializers.Serializer):
+    status = serializers.CharField(allow_null=True)
+
+
+class MarkRunCompromisedRequestSerializer(serializers.Serializer):
+    comment = serializers.CharField()
+    bug_id = serializers.CharField(required=False, allow_null=True)
+    reference_key = serializers.CharField(required=False, allow_null=True)
+
+
+class MarkRunCompromisedResponseSerializer(serializers.Serializer):
+    comment = serializers.CharField()
+    bug = serializers.CharField(allow_null=True)
+
+
+class UnmarkRunCompromisedResponseSerializer(serializers.Serializer):
+    message = serializers.CharField()
+
+
+class RunCommentRequestSerializer(serializers.Serializer):
+    comment = serializers.CharField()
+
+
+class RunCommentValueResponseSerializer(serializers.Serializer):
+    comment = serializers.CharField(allow_null=True)
+
+
+class RunCommentResponseSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    comment = serializers.CharField()
+
+
+class RunChartTestsSerializer(serializers.Serializer):
+    ok = serializers.IntegerField()
+    nok = serializers.IntegerField()
+    total = serializers.IntegerField()
+    passrate = serializers.FloatField()
+
+
+class RunIdsByStatusSerializer(serializers.Serializer):
+    run_ok = serializers.ListField(
+        source='run-ok',
+        child=serializers.IntegerField(),
+    )
+    run_running = serializers.ListField(
+        source='run-running',
+        child=serializers.IntegerField(),
+    )
+    run_warning = serializers.ListField(
+        source='run-warning',
+        child=serializers.IntegerField(),
+    )
+    run_error = serializers.ListField(
+        source='run-error',
+        child=serializers.IntegerField(),
+    )
+    run_stopped = serializers.ListField(
+        source='run-stopped',
+        child=serializers.IntegerField(),
+    )
+    run_busy = serializers.ListField(
+        source='run-busy',
+        child=serializers.IntegerField(),
+    )
+    run_compromised = serializers.ListField(
+        source='run-compromised',
+        child=serializers.IntegerField(),
+    )
+    run_interrupted = serializers.ListField(
+        source='run-interrupted',
+        child=serializers.IntegerField(),
+    )
+
+
+class RunChartBucketSerializer(serializers.Serializer):
+    date = serializers.DateTimeField()
+    tests = RunChartTestsSerializer()
+    run_ids_by_status = RunIdsByStatusSerializer()
+
+
+class RunChartsResponseSerializer(serializers.Serializer):
+    buckets = RunChartBucketSerializer(many=True)
 
 
 def serialize_run_compromised_details(

--- a/bublik/interfaces/api_v2/run/views.py
+++ b/bublik/interfaces/api_v2/run/views.py
@@ -14,7 +14,7 @@ from bublik.core.run.stats import (
     generate_runs_details,
 )
 from bublik.core.utils import get_difference
-from bublik.data.models import GlobalConfigs, TestIterationResult
+from bublik.data.models import GlobalConfigs
 from bublik.data.serializers import (
     RunCommentSerializer,
     TestIterationResultSerializer,
@@ -102,7 +102,8 @@ class RunViewSet(ModelViewSet):
     @action(detail=True, methods=['get'])
     def stats(self, _request, pk=None):
         requirements = self.request.query_params.get('requirements')
-        project_id = TestIterationResult.objects.get(id=pk).project.id
+        run = RunService.get_run(pk)
+        project_id = run.project.id
         run_stats = RunService.get_run_stats(pk, requirements)
         return Response(
             {

--- a/bublik/interfaces/api_v2/run/views.py
+++ b/bublik/interfaces/api_v2/run/views.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2016-2023 OKTET Labs Ltd. All rights reserved.
 
+from typing import ClassVar
+
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
@@ -16,10 +18,18 @@ from bublik.core.run.stats import (
 from bublik.core.utils import get_difference
 from bublik.data.models import GlobalConfigs
 from bublik.data.serializers import (
-    RunCommentSerializer,
     TestIterationResultSerializer,
 )
+from bublik.interfaces.api_v2.run.schemas import (
+    create_comment_schema,
+    delete_comment_schema,
+    mark_compromised_schema,
+    run_viewset_schema,
+    unmark_compromised_schema,
+    update_comment_schema,
+)
 from bublik.interfaces.api_v2.run.serializers import (
+    RunCommentRequestSerializer,
     serialize_mark_run_compromised_result,
     serialize_run_comment_result,
     serialize_run_details,
@@ -33,8 +43,10 @@ __all__ = [
 ]
 
 
+@run_viewset_schema
 class RunViewSet(ModelViewSet):
     serializer_class = TestIterationResultSerializer
+    filter_backends: ClassVar[list] = []
 
     def get_queryset(self):
         query_params = self.request.query_params
@@ -128,19 +140,25 @@ class RunViewSet(ModelViewSet):
     def status(self, _request, pk=None):
         return Response({'status': RunService.get_run_status(pk)})
 
-    @action(detail=True, methods=['get', 'post', 'delete'])
-    def compromised(self, request, pk=None):
-        if request.method == 'GET':
-            return Response(RunService.get_run_compromised(pk))
-        if request.method == 'POST':
-            comment = request.data.get('comment')
-            bug_id = request.data.get('bug_id')
-            reference_key = request.data.get('reference_key')
-            return Response(
-                serialize_mark_run_compromised_result(
-                    RunService.mark_run_compromised(pk, comment, bug_id, reference_key),
-                ),
-            )
+    @action(detail=True, methods=['get'])
+    def compromised(self, _request, pk=None):
+        return Response(RunService.get_run_compromised(pk))
+
+    @mark_compromised_schema
+    @compromised.mapping.post
+    def mark_compromised(self, request, pk=None):
+        comment = request.data.get('comment')
+        bug_id = request.data.get('bug_id')
+        reference_key = request.data.get('reference_key')
+        return Response(
+            serialize_mark_run_compromised_result(
+                RunService.mark_run_compromised(pk, comment, bug_id, reference_key),
+            ),
+        )
+
+    @unmark_compromised_schema
+    @compromised.mapping.delete
+    def unmark_compromised(self, _request, pk=None):
         try:
             RunService.unmark_run_compromised(pk)
             return Response({'message': f'Run {pk} is no longer compromised'})
@@ -150,29 +168,32 @@ class RunViewSet(ModelViewSet):
 
     @action(
         detail=True,
-        methods=['get', 'post', 'put', 'delete'],
-        serializer_class=RunCommentSerializer,
+        methods=['get'],
+        serializer_class=RunCommentRequestSerializer,
     )
-    def comment(self, request, pk=None):
-        if request.method == 'GET':
-            comment = RunService.get_run_comment(pk)
-            return Response({'comment': comment})
+    def comment(self, _request, pk=None):
+        comment = RunService.get_run_comment(pk)
+        return Response({'comment': comment})
 
-        if request.method == 'POST':
-            content = request.data.get('comment')
-            result = RunService.create_run_comment(pk, content)
-            return Response(
-                serialize_run_comment_result(result),
-                status=status.HTTP_201_CREATED,
-            )
+    @create_comment_schema
+    @comment.mapping.post
+    def create_comment(self, request, pk=None):
+        content = request.data.get('comment')
+        result = RunService.create_run_comment(pk, content)
+        return Response(
+            serialize_run_comment_result(result),
+            status=status.HTTP_201_CREATED,
+        )
 
-        if request.method == 'PUT':
-            content = request.data.get('comment')
-            result = RunService.create_run_comment(pk, content)
-            return Response(serialize_run_comment_result(result), status=status.HTTP_200_OK)
+    @update_comment_schema
+    @comment.mapping.put
+    def update_comment(self, request, pk=None):
+        content = request.data.get('comment')
+        result = RunService.create_run_comment(pk, content)
+        return Response(serialize_run_comment_result(result), status=status.HTTP_200_OK)
 
-        if request.method == 'DELETE':
-            RunService.delete_run_comment(pk)
-            return Response(status=status.HTTP_204_NO_CONTENT)
-
-        return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
+    @delete_comment_schema
+    @comment.mapping.delete
+    def delete_comment(self, _request, pk=None):
+        RunService.delete_run_comment(pk)
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Description

### Summary

Update API v2 OpenAPI schema definitions so run and result endpoint
documentation matches the current response payloads.

### Changes

- Add and update run endpoint request/response serializers.
- Document run stats responses, including `default_columns`.
- Document run charts, comments, compromised status, requirements,
  source, status, details, and NOK distribution responses.
- Add and update result endpoint response schemas.
- Keep OpenAPI definitions aligned with DTO-backed service responses.