### PR TITLE
Utils: fix typo in binary multiplier key

### DIFF
--- a/bublik/core/utils.py
+++ b/bublik/core/utils.py
@@ -150,7 +150,7 @@ def get_metric_prefix_units(multiplier, base_units):
         '1e-3': ['milli', 'm'],
         '1': ['plain', ''],
         '1e+3': ['kilo', 'k'],
-        '1x1p10': ['kibi', 'Ki'],
+        '0x1p10': ['kibi', 'Ki'],
         '1e+6': ['mega', 'M'],
         '0x1p20': ['mebi', 'Mi'],
         '1e+9': ['giga', 'G'],


### PR DESCRIPTION
The kibi prefix key used '1x1p10', an invalid hex float literal that never matched, so the Ki prefix was never resolved. Changed it to the correct '0x1p10' (2^10), matching the format used by the other binary prefixes.