### PR TITLE
Run data: fix tags missing from project and default cache entries

### DIFF
--- a/bublik/core/cache.py
+++ b/bublik/core/cache.py
@@ -233,28 +233,43 @@ class _TagsCache(_ProjectSectionCache):
             - 'all': all project-related tags with category priority 1-9
               or without a category
 
+        If project_id is None, tags are filtered by the default (project-less)
+        categories; 'relevant' contains all tags not in 'important', and 'all'
+        contains every tag in the database.
+
         Value format:
             {meta_id: 'tag_name=tag_value'}
         """
 
         tags = models.Meta.objects.filter(type='tag')
 
-        important_tags_data = tags.filter(
-            category__priority__range=(1, 3),
-            category__project_id=self._project._project_id,
-        ).order_by('category__priority', 'name')
+        project_id = self._project._project_id
+        if project_id is not None:
+            important_tags_data = tags.filter(
+                category__priority__range=(1, 3),
+                category__project_id=project_id,
+            ).order_by('category__priority', 'name')
 
-        relevant_tags_data = tags.filter(
-            Q(category__priority__range=(4, 9))
-            & Q(category__project_id=self._project._project_id)
-            | Q(category__isnull=True),
-        ).order_by('category__priority', 'name')
+            relevant_tags_data = tags.filter(
+                Q(category__priority__range=(4, 9)) & Q(category__project_id=project_id)
+                | Q(category__isnull=True),
+            ).order_by('category__priority', 'name')
 
-        tags_data = tags.filter(
-            Q(category__priority__range=(1, 9))
-            & Q(category__project_id=self._project._project_id)
-            | Q(category__isnull=True),
-        ).order_by('category__priority', 'name')
+            all_tags_data = tags.filter(
+                Q(category__priority__range=(1, 9)) & Q(category__project_id=project_id)
+                | Q(category__isnull=True),
+            ).order_by('category__priority', 'name')
+        else:
+            important_tags_data = tags.filter(
+                category__priority__range=(1, 3),
+                category__project_id__isnull=True,
+            ).order_by('category__priority', 'name')
+
+            relevant_tags_data = tags.exclude(
+                id__in=important_tags_data,
+            ).order_by('name')
+
+            all_tags_data = tags.order_by('name')
 
         def prepare_tags(tags_data):
             tags = {}
@@ -264,7 +279,7 @@ class _TagsCache(_ProjectSectionCache):
 
         self.set('important', prepare_tags(important_tags_data))
         self.set('relevant', prepare_tags(relevant_tags_data))
-        self.set('all', prepare_tags(tags_data))
+        self.set('all', prepare_tags(all_tags_data))
 
 
 class _TestsCache(_ProjectSectionCache):

--- a/bublik/core/cache.py
+++ b/bublik/core/cache.py
@@ -233,9 +233,13 @@ class _TagsCache(_ProjectSectionCache):
             - 'all': all project-related tags with category priority 1-9
               or without a category
 
-        If project_id is None, tags are filtered by the default (project-less)
-        categories; 'relevant' contains all tags not in 'important', and 'all'
-        contains every tag in the database.
+        If project_id is specified, only tags appearing in that project's
+        runs are considered. Tags not categorised for the project (including
+        those categorised in other projects) are treated as uncategorised
+        and included in 'relevant' and 'all'. If project_id is None, tags
+        are filtered by the default (project-less) categories; 'relevant'
+        contains all tags not in 'important', and 'all' contains every tag
+        in the database.
 
         Value format:
             {meta_id: 'tag_name=tag_value'}
@@ -245,19 +249,28 @@ class _TagsCache(_ProjectSectionCache):
 
         project_id = self._project._project_id
         if project_id is not None:
-            important_tags_data = tags.filter(
+            project_tags = tags.filter(
+                metaresult__result__project_id=project_id,
+                metaresult__result__test_run__isnull=True,
+            ).distinct()
+
+            project_uncategorised_tags = project_tags.exclude(
+                id__in=project_tags.filter(category__project_id=project_id),
+            ).distinct()
+
+            important_tags_data = project_tags.filter(
                 category__priority__range=(1, 3),
                 category__project_id=project_id,
             ).order_by('category__priority', 'name')
 
-            relevant_tags_data = tags.filter(
+            relevant_tags_data = project_tags.filter(
                 Q(category__priority__range=(4, 9)) & Q(category__project_id=project_id)
-                | Q(category__isnull=True),
+                | Q(id__in=project_uncategorised_tags),
             ).order_by('category__priority', 'name')
 
-            all_tags_data = tags.filter(
+            all_tags_data = project_tags.filter(
                 Q(category__priority__range=(1, 9)) & Q(category__project_id=project_id)
-                | Q(category__isnull=True),
+                | Q(id__in=project_uncategorised_tags),
             ).order_by('category__priority', 'name')
         else:
             important_tags_data = tags.filter(


### PR DESCRIPTION
## Problem
Tags cache (`_TagsCache`) had two issues affecting tag visibility.
For projects: tags appearing in a project's runs were invisible if they had been categorized in another project. The uncategorized filter relied on `category__isnull=True`, which only captured tags with no category at all, excluding cross-project categorized tags.
For default context (`project_id=None`): `category__project_id=None` incorrectly captured tags without any category via LEFT JOIN, and `category__isnull=True` excluded tags categorized in projects from 'relevant' and 'all'.

## Solution
For projects: the cache is now populated from tags actually appearing in that project's runs. Tags not categorized for the project are treated as uncategorized and included in 'relevant' and 'all', regardless of whether they are categorized in other projects.
For default context: 'important' now uses `project_id__isnull=True` to correctly match only default categories. 'relevant' contains all tags not in 'important', and 'all' contains every tag in the database.