### PR TITLE
URL: fix short URL generation and resolution

### DIFF
--- a/bublik/core/config/reformatting/piplines.py
+++ b/bublik/core/config/reformatting/piplines.py
@@ -6,6 +6,7 @@ import logging
 from bublik.core.config.reformatting.steps import (
     AllowMultipleSeriesArgs,
     BaseReformatStep,
+    EnsureSupportedUIVersion,
     ImproveMetaStructure,
     MergeDashboardSettings,
     RemoveUnsupportedAttributes,
@@ -57,6 +58,7 @@ class PerConfConfigReformatPipeline(ReformatPipeline):
         self.add_step(UpdateDashboardHeaderStructure())
         self.add_step(UpdateCSRFTrustedOrigins())
         self.add_step(MergeDashboardSettings())
+        self.add_step(EnsureSupportedUIVersion())
 
 
 class ReferencesConfigReformatPipeline(ReformatPipeline):

--- a/bublik/core/config/reformatting/steps.py
+++ b/bublik/core/config/reformatting/steps.py
@@ -517,3 +517,25 @@ class MergeDashboardSettings(BaseReformatStep):
             config.content['DASHBOARD_RUNS_SORT'] = db_runs_sort
 
         return config
+
+
+class EnsureSupportedUIVersion(BaseReformatStep):
+    """
+    Reformat passed global per_conf config content:
+    Only UI version 2 is supported. Any other value is replaced with 2.
+
+    Example:
+    "UI_VERSION": 1 -> "UI_VERSION": 2
+    """
+
+    SUPPORTED_UI_VERSION = 2
+
+    def applied(self, config, **kwargs):
+        return (
+            'UI_VERSION' not in config.content
+            or config.content['UI_VERSION'] == self.SUPPORTED_UI_VERSION
+        )
+
+    def reformat(self, config, **kwargs):
+        config.content['UI_VERSION'] = self.SUPPORTED_UI_VERSION
+        return config

--- a/bublik/data/schemas/per_conf.json
+++ b/bublik/data/schemas/per_conf.json
@@ -11,6 +11,7 @@
         "UI_VERSION": {
             "description": "Default UI version",
             "type": "number",
+            "enum": [2],
             "default": 2
         },
         "EMAIL_PROJECT_WATCHERS": {

--- a/bublik/data/serializers/endpoint_url.py
+++ b/bublik/data/serializers/endpoint_url.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2024 OKTET Labs Ltd. All rights reserved.
 
-from base64 import b64encode
+from base64 import urlsafe_b64encode
 from hashlib import blake2s
 
 from bublik.core.hash_system import HashedModelSerializer
@@ -17,7 +17,7 @@ def blake2sb64hex(obj):
     if isinstance(obj, str):
         obj = obj.encode('utf-8')
     enc_key = blake2s(obj, digest_size=8).digest()
-    return b64encode(enc_key).decode('utf-8')
+    return urlsafe_b64encode(enc_key).decode('utf-8')
 
 
 class EndpointURLSerializer(HashedModelSerializer):


### PR DESCRIPTION
Fix two issues that cause short URLs to be generated incorrectly or fail to resolve.

- Standard base64 encoding used for short URL hashes can produce URL-unsafe characters, causing resolution to fail with 404. Switch to URL-safe base64 encoding to avoid this.

- An unsupported `UI_VERSION` in the project config results in an empty `UI_PREFIX`, causing the URL shortener to parse the original URL incorrectly and store a broken short URL. Add a schema constraint and a reformat step to ensure only version 2 is used.

Closes: #340
Closes: #341